### PR TITLE
Add bioclip command line tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,165 @@
 # pybioclip
-Python package to simplify use of BioCLIP
+
+
+[![PyPI - Version](https://img.shields.io/pypi/v/bioclip.svg)](https://pypi.org/project/bioclip)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/bioclip.svg)](https://pypi.org/project/bioclip)
+
+-----
+
+Command line tool and python package to simplify using [BioCLIP](https://imageomics.github.io/bioclip/).
+
+
+**Table of Contents**
+
+- [Installation](#installation)
+- [Command Line Usage](#command-line-usage)
+- [Python Package Usage](#python-package-usage)
+- [License](#license)
+- [Acknowledgments](#acknowledgments)
+- [License](#license)
+  
+## Requirements
+- Python compatible with [PyTorch](https://pytorch.org/get-started/locally/#linux-python)
+
+## Installation
+
+```console
+pip install git+https://github.com/Imageomics/pybioclip
+```
+
+If you have any issues with installation, please first upgrade pip by running `pip install --upgrade pip`.
+
+## Command Line Usage
+
+### Predict classification
+
+#### Example: Predict species for an image
+The example image used below is [`Ursus-arctos.jpeg`](https://huggingface.co/spaces/imageomics/bioclip-demo/blob/ef075807a55687b320427196ac1662b9383f988f/examples/Ursus-arctos.jpeg) from the [bioclip-demo](https://huggingface.co/spaces/imageomics/bioclip-demo).
+
+Predict species for an `Ursus-arctos.jpeg` file:
+```console
+bioclip predict Ursus-arctos.jpeg
+```
+Output:
+```
++----------------------------------------------------------------------------------------+-----------------------+
+|                                         Taxon                                          |      Probability      |
++----------------------------------------------------------------------------------------+-----------------------+
+|        Animalia Chordata Mammalia Carnivora Ursidae Ursus arctos (Kodiak bear)         |   0.9356034994125366  |
+| Animalia Chordata Mammalia Carnivora Ursidae Ursus arctos syriacus (syrian brown bear) |  0.05616999790072441  |
+|          Animalia Chordata Mammalia Carnivora Ursidae Ursus arctos bruinosus           |  0.004126196261495352 |
+|               Animalia Chordata Mammalia Carnivora Ursidae Ursus arctus                | 0.0024959812872111797 |
+|  Animalia Chordata Mammalia Carnivora Ursidae Ursus americanus (Louisiana black bear)  | 0.0005009894957765937 |
++----------------------------------------------------------------------------------------+-----------------------+
+```
+
+---
+
+To save as a CSV or JSON file you can use the `--format <file type>` and `--output <filename>` arguments with `csv` or `json`, respectively.
+
+To save the JSON output to `ursus.json` run:
+```console
+bioclip predict --format json --output ursus.json Ursus-arctos.jpeg 
+```
+
+To save the CSV output to `ursus.csv` run:
+```console
+bioclip predict --format csv --output ursus.csv Ursus-arctos.jpeg 
+```
+
+#### Predict genus for an image
+
+Predict genus for image `Ursus-arctos.jpeg`, restricted to the top 3 predictions:
+```console
+bioclip predict --rank genus --k 3 Ursus-arctos.jpeg
+```
+Output:
+```
++---------------------------------------------------------+------------------------+
+|                          Taxon                          |      Probability       |
++---------------------------------------------------------+------------------------+
+|    Animalia Chordata Mammalia Carnivora Ursidae Ursus   |   0.9994320273399353   |
+| Animalia Chordata Mammalia Artiodactyla Cervidae Cervus | 0.00032594642834737897 |
+|  Animalia Chordata Mammalia Artiodactyla Cervidae Alces | 7.803700282238424e-05  |
++---------------------------------------------------------+------------------------+
+```
+
+#### Optional arguments for predicting classifications:
+- `--rank RANK` - rank of the classification (kingdom, phylum, class, order, family, genus, species) [default: species] 
+- `--k K` - number of top predictions to show [default: 5]
+- `--format FORMAT` - format of the output (table, json, or csv) [default: table]
+- `--output OUTPUT` - save output to a filename instead of printing it [default: stdout]
+
+
+### Predict from a list of classes
+
+Create predictions for 3 classes (cat, bird, and bear) for image `Ursus-arctos.jpeg`:
+```console
+bioclip predict --cls cat,bird,bear Ursus-arctos.jpeg
+```
+Output:
+```
++-------+-----------------------+
+| Taxon |      Probability      |
++-------+-----------------------+
+|  cat  | 4.581644930112816e-08 |
+|  bird | 3.051998476166773e-08 |
+|  bear |   0.9999998807907104  |
++-------+-----------------------+%                                                                  
+```
+
+#### Optional arguments for predicting from a list of classes:
+- `--format FORMAT` - format of the output (table, json, or csv) [default: table]
+- `--output OUTPUT` - save output to a filename instead of printing it [default: stdout]
+- `--cls CLS` - comma separated list of classes to predict, when specified the `--rank` and `--k` arguments are ignored [default: all]
+
+
+### View command line help
+```console
+bioclip --help
+```
+
+## Python Package Usage
+### Predict species classification
+
+```python
+from bioclip import predict_classification, Rank
+
+predictions = predict_classification("Ursus-arctos.jpeg", Rank.SPECIES)
+
+for species_name, probability in predictions.items():
+   print(species_name, probability)
+```
+
+Output:
+```console
+Animalia Chordata Mammalia Carnivora Ursidae Ursus arctos (Kodiak bear) 0.9356034994125366
+Animalia Chordata Mammalia Carnivora Ursidae Ursus arctos syriacus (syrian brown bear) 0.05616999790072441
+Animalia Chordata Mammalia Carnivora Ursidae Ursus arctos bruinosus 0.004126196261495352
+Animalia Chordata Mammalia Carnivora Ursidae Ursus arctus 0.0024959812872111797
+Animalia Chordata Mammalia Carnivora Ursidae Ursus americanus (Louisiana black bear) 0.0005009894957765937
+```
+
+### Predict from a list of classes
+```python
+from bioclip import predict_classifications_from_list, Rank
+
+predictions = predict_classifications_from_list("Ursus-arctos.jpeg",
+                                                ["duck","fish","bear"])
+
+for cls, probability in predictions.items():
+   print(cls, probability)
+```
+Output:
+```console
+duck 1.0306726583309e-09
+fish 2.932403668845507e-12
+bear 1.0
+```
+
+## License
+
+`pybioclip` is distributed under the terms of the [MIT](https://spdx.org/licenses/MIT.html) license.
+
+## Acknowledgments
+The [prediction code in this repo](src/bioclip/predict.py) is based on work by [@samuelstevens](https://github.com/samuelstevens) in [bioclip-demo](https://huggingface.co/spaces/imageomics/bioclip-demo/tree/ef075807a55687b320427196ac1662b9383f988f).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,92 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/bioclip"]
+
+[project]
+name = "pybioclip"
+dynamic = ["version"]
+description = 'Python package that simplifies using the BioCLIP foundation model.'
+readme = "README.md"
+requires-python = ">=3.8"
+license = "MIT"
+keywords = []
+authors = [
+  { name = "John Bradley", email = "johnbradley2008@gmail.com" },
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy"
+]
+dependencies = [
+  'open_clip_torch',
+  'torchvision',
+  'torch',
+  'docopt-ng',
+  'prettytable',
+]
+
+[project.urls]
+Documentation = "https://github.com/Imageomics/pybioclip#readme"
+Issues = "https://github.com/Imageomics/pybioclip/issues"
+Source = "https://github.com/Imageomics/pybioclip"
+
+[project.scripts]
+bioclip = "bioclip.__main__:main"
+
+[tool.hatch.version]
+path = "src/bioclip/__about__.py"
+
+[tool.hatch.envs.default]
+dependencies = [
+  "coverage[toml]>=6.5",
+  "pytest",
+]
+[tool.hatch.envs.default.scripts]
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+cov-report = [
+  "- coverage combine",
+  "coverage report",
+]
+cov = [
+  "test-cov",
+  "cov-report",
+]
+
+[[tool.hatch.envs.all.matrix]]
+python = ["3.8", "3.9", "3.10", "3.11"]
+
+[tool.hatch.envs.types]
+dependencies = [
+  "mypy>=1.0.0",
+]
+[tool.hatch.envs.types.scripts]
+check = "mypy --install-types --non-interactive {args:src/bioclip tests}"
+
+[tool.coverage.run]
+source_pkgs = ["bioclip", "tests"]
+branch = true
+parallel = true
+omit = [
+  "src/bioclip/__about__.py",
+]
+
+[tool.coverage.paths]
+bioclip = ["src/bioclip", "*/bioclip/src/bioclip"]
+tests = ["tests", "*/bioclip/tests"]
+
+[tool.coverage.report]
+exclude_lines = [
+  "no cov",
+  "if __name__ == .__main__.:",
+  "if TYPE_CHECKING:",
+]

--- a/src/bioclip/__about__.py
+++ b/src/bioclip/__about__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2024-present John Bradley <johnbradley2008@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+__version__ = "0.0.1"

--- a/src/bioclip/__init__.py
+++ b/src/bioclip/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2024-present John Bradley <johnbradley2008@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from bioclip.predict import predict_classification, Rank, predict_classifications_from_list
+
+__all__ = ["predict_classification", "Rank", "predict_classifications_from_list"]

--- a/src/bioclip/__main__.py
+++ b/src/bioclip/__main__.py
@@ -1,0 +1,70 @@
+"""Usage: bioclip predict [options] IMAGE_FILE 
+
+Use BioCLIP to generate predictions for an IMAGE_FILE.
+
+Arguments:
+  IMAGE_FILE           input image file
+
+Options:
+  -h --help
+  --format=FORMAT      format of the output (table, json, or csv) [default: table]
+  --rank=RANK          rank of the classification (kingdom, phylum, class, order, family, genus, species) [default: species] 
+  --k=K                number of top predictions to show [default: 5]
+  --cls=CLS            comma separated list of classes to predict, when specified the --rank and --k arguments are ignored [default: all]
+  --output=OUTFILE     save output to a filename instead of printing it [default: stdout]
+
+"""
+from docopt import docopt
+from bioclip import predict_classification, predict_classifications_from_list, Rank
+import json
+import sys
+import prettytable as pt
+import csv
+
+
+def write_results(result, format, outfile):
+    if format == 'table':
+        table = pt.PrettyTable()
+        table.field_names = ['Taxon', 'Probability']
+        for taxon, prob in result.items():
+            table.add_row([taxon, prob])
+        outfile.write(str(table))
+        outfile.write('\n')
+    elif format == 'json':
+        json.dump(result, outfile, indent=2)
+    elif format == 'csv':
+        writer = csv.writer(outfile)
+        writer.writerow(['Taxon', 'Probability'])
+        for taxon, prob in result.items():
+            writer.writerow([taxon, prob])
+    else:
+        raise ValueError(f"Invalid format: {format}")
+
+
+def main():
+    # execute only if run as the entry point into the program
+    x = docopt(__doc__)  # parse arguments based on docstring above
+    format = x['--format']
+    output = x['--output']
+    image_file = x['IMAGE_FILE']
+    cls = x['--cls']
+    if not format in ['table', 'json', 'csv']:
+        raise ValueError(f"Invalid format: {format}")
+    rank = Rank[x['--rank'].upper()]
+    if cls == 'all':
+        result = predict_classification(img=image_file,
+                                        rank=rank,
+                                        k=int(x['--k']))
+    else:
+        result = predict_classifications_from_list(img=image_file, 
+                                                   cls_ary=cls.split(','))
+    outfile = sys.stdout
+    if output == 'stdout':
+        write_results(result, format, sys.stdout)
+    else:
+        with open(output, 'w') as outfile:
+            write_results(result, format, outfile)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/bioclip/predict.py
+++ b/src/bioclip/predict.py
@@ -1,0 +1,222 @@
+import json
+import torch
+from torchvision import transforms
+from open_clip import create_model, get_tokenizer
+import torch.nn.functional as F
+import numpy as np
+import collections
+import heapq
+import PIL.Image
+from huggingface_hub import hf_hub_download
+from typing import Union, List
+from enum import Enum
+
+HF_DATAFILE_REPO = "imageomics/bioclip-demo"
+HF_DATAFILE_REPO_TYPE = "space"
+
+
+def get_cached_datafile(filename:str):
+    return hf_hub_download(repo_id=HF_DATAFILE_REPO, filename=filename, repo_type=HF_DATAFILE_REPO_TYPE)
+
+
+def get_txt_emb():
+    txt_emb_npy = get_cached_datafile("txt_emb_species.npy")
+    return torch.from_numpy(np.load(txt_emb_npy))
+
+
+def get_txt_names():
+    txt_names_json = get_cached_datafile("txt_emb_species.json")
+    with open(txt_names_json) as fd:
+        txt_names = json.load(fd)
+    return txt_names
+
+preprocess_img = transforms.Compose(
+    [
+        transforms.ToTensor(),
+        transforms.Resize((224, 224), antialias=True),
+        transforms.Normalize(
+            mean=(0.48145466, 0.4578275, 0.40821073),
+            std=(0.26862954, 0.26130258, 0.27577711),
+        ),
+    ]
+)
+
+OPENA_AI_IMAGENET_TEMPLATE = [
+    lambda c: f"a bad photo of a {c}.",
+    lambda c: f"a photo of many {c}.",
+    lambda c: f"a sculpture of a {c}.",
+    lambda c: f"a photo of the hard to see {c}.",
+    lambda c: f"a low resolution photo of the {c}.",
+    lambda c: f"a rendering of a {c}.",
+    lambda c: f"graffiti of a {c}.",
+    lambda c: f"a bad photo of the {c}.",
+    lambda c: f"a cropped photo of the {c}.",
+    lambda c: f"a tattoo of a {c}.",
+    lambda c: f"the embroidered {c}.",
+    lambda c: f"a photo of a hard to see {c}.",
+    lambda c: f"a bright photo of a {c}.",
+    lambda c: f"a photo of a clean {c}.",
+    lambda c: f"a photo of a dirty {c}.",
+    lambda c: f"a dark photo of the {c}.",
+    lambda c: f"a drawing of a {c}.",
+    lambda c: f"a photo of my {c}.",
+    lambda c: f"the plastic {c}.",
+    lambda c: f"a photo of the cool {c}.",
+    lambda c: f"a close-up photo of a {c}.",
+    lambda c: f"a black and white photo of the {c}.",
+    lambda c: f"a painting of the {c}.",
+    lambda c: f"a painting of a {c}.",
+    lambda c: f"a pixelated photo of the {c}.",
+    lambda c: f"a sculpture of the {c}.",
+    lambda c: f"a bright photo of the {c}.",
+    lambda c: f"a cropped photo of a {c}.",
+    lambda c: f"a plastic {c}.",
+    lambda c: f"a photo of the dirty {c}.",
+    lambda c: f"a jpeg corrupted photo of a {c}.",
+    lambda c: f"a blurry photo of the {c}.",
+    lambda c: f"a photo of the {c}.",
+    lambda c: f"a good photo of the {c}.",
+    lambda c: f"a rendering of the {c}.",
+    lambda c: f"a {c} in a video game.",
+    lambda c: f"a photo of one {c}.",
+    lambda c: f"a doodle of a {c}.",
+    lambda c: f"a close-up photo of the {c}.",
+    lambda c: f"a photo of a {c}.",
+    lambda c: f"the origami {c}.",
+    lambda c: f"the {c} in a video game.",
+    lambda c: f"a sketch of a {c}.",
+    lambda c: f"a doodle of the {c}.",
+    lambda c: f"a origami {c}.",
+    lambda c: f"a low resolution photo of a {c}.",
+    lambda c: f"the toy {c}.",
+    lambda c: f"a rendition of the {c}.",
+    lambda c: f"a photo of the clean {c}.",
+    lambda c: f"a photo of a large {c}.",
+    lambda c: f"a rendition of a {c}.",
+    lambda c: f"a photo of a nice {c}.",
+    lambda c: f"a photo of a weird {c}.",
+    lambda c: f"a blurry photo of a {c}.",
+    lambda c: f"a cartoon {c}.",
+    lambda c: f"art of a {c}.",
+    lambda c: f"a sketch of the {c}.",
+    lambda c: f"a embroidered {c}.",
+    lambda c: f"a pixelated photo of a {c}.",
+    lambda c: f"itap of the {c}.",
+    lambda c: f"a jpeg corrupted photo of the {c}.",
+    lambda c: f"a good photo of a {c}.",
+    lambda c: f"a plushie {c}.",
+    lambda c: f"a photo of the nice {c}.",
+    lambda c: f"a photo of the small {c}.",
+    lambda c: f"a photo of the weird {c}.",
+    lambda c: f"the cartoon {c}.",
+    lambda c: f"art of the {c}.",
+    lambda c: f"a drawing of the {c}.",
+    lambda c: f"a photo of the large {c}.",
+    lambda c: f"a black and white photo of a {c}.",
+    lambda c: f"the plushie {c}.",
+    lambda c: f"a dark photo of a {c}.",
+    lambda c: f"itap of a {c}.",
+    lambda c: f"graffiti of the {c}.",
+    lambda c: f"a toy {c}.",
+    lambda c: f"itap of my {c}.",
+    lambda c: f"a photo of a cool {c}.",
+    lambda c: f"a photo of a small {c}.",
+    lambda c: f"a tattoo of the {c}.",
+]
+
+
+class Rank(Enum):
+    KINGDOM = 0
+    PHYLUM = 1
+    CLASS = 2
+    ORDER = 3
+    FAMILY = 4
+    GENUS = 5
+    SPECIES = 6
+
+
+def create_bioclip_model(model_str="hf-hub:imageomics/bioclip", device="cuda"):
+    model = create_model(model_str, output_dict=True, require_pretrained=True)
+    model = model.to(device)
+    return torch.compile(model)
+
+
+def create_bioclip_tokenizer(tokenizer_str="ViT-B-16"):
+    return get_tokenizer(tokenizer_str)
+
+
+@torch.no_grad()
+def get_txt_features(classnames, templates, tokenizer, model, device):
+    all_features = []
+    for classname in classnames:
+        txts = [template(classname) for template in templates]
+        txts = tokenizer(txts).to(device)
+        txt_features = model.encode_text(txts)
+        txt_features = F.normalize(txt_features, dim=-1).mean(dim=0)
+        txt_features /= txt_features.norm()
+        all_features.append(txt_features)
+    all_features = torch.stack(all_features, dim=1)
+    return all_features
+
+
+@torch.no_grad()
+def predict_classifications_from_list(img: Union[PIL.Image.Image, str], cls_ary: List[str], device: Union[str, torch.device] = 'cpu') -> dict[str, float]:
+    if isinstance(img,str):
+       img = PIL.Image.open(img)
+    model = create_bioclip_model(device=device)
+    tokenizer = create_bioclip_tokenizer()
+    
+    classes = [cls.strip() for cls in cls_ary]
+    txt_features = get_txt_features(classes, OPENA_AI_IMAGENET_TEMPLATE, tokenizer=tokenizer, model=model, device=device)
+
+    img = preprocess_img(img).to(device)
+    img_features = model.encode_image(img.unsqueeze(0))
+    img_features = F.normalize(img_features, dim=-1)
+
+    logits = (model.logit_scale.exp() * img_features @ txt_features).squeeze()
+    probs = F.softmax(logits, dim=0).to("cpu").tolist()
+    return {cls: prob for cls, prob in zip(classes, probs)}
+
+
+def format_name(taxon, common):
+    taxon = " ".join(taxon)
+    if not common:
+        return taxon
+    return f"{taxon} ({common})"
+
+
+@torch.no_grad()
+def predict_classification(img: Union[PIL.Image.Image, str], rank: Rank, device: Union[str, torch.device] = 'cpu',
+                               min_prob: float = 1e-9, k: int = 5) -> dict[str, float]:
+    """
+    Predicts from the entire tree of life.
+    If targeting a higher rank than species, then this function predicts among all
+    species, then sums up species-level probabilities for the given rank.
+    """
+    if isinstance(img,str):
+       img = PIL.Image.open(img)
+    model = create_bioclip_model(device=device)
+    img = preprocess_img(img).to(device)
+    txt_emb = get_txt_emb().to(device)
+    txt_names = get_txt_names()
+    img_features = model.encode_image(img.unsqueeze(0))
+    img_features = F.normalize(img_features, dim=-1)
+
+    logits = (model.logit_scale.exp() * img_features @ txt_emb).squeeze()
+    probs = F.softmax(logits, dim=0)
+
+    # If predicting species, no need to sum probabilities.
+    if rank == Rank.SPECIES:
+        topk = probs.topk(k)
+        return {
+            format_name(*txt_names[i]): prob.item() for i, prob in zip(topk.indices, topk.values)
+        }
+    # Sum up by the rank
+    output = collections.defaultdict(float)
+    for i in torch.nonzero(probs > min_prob).squeeze():
+        output[" ".join(txt_names[i][0][: rank.value + 1])] += probs[i]
+
+    topk_names = heapq.nlargest(k, output, key=output.get)
+
+    return {name: output[name].item() for name in topk_names}
+

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024-present John Bradley <johnbradley2008@gmail.com>
+#
+# SPDX-License-Identifier: MIT


### PR DESCRIPTION
Adds python package with command line bioclip tool. The code in predict.py is based on app.py and supporting code from https://huggingface.co/spaces/imageomics/bioclip-demo, commit [ef075807a55687b320427196ac1662b9383f988f](https://huggingface.co/spaces/imageomics/bioclip-demo/commit/ef075807a55687b320427196ac1662b9383f988f), by @samuelstevens.

Excluding python 3.12 since pytorch doesn't support it.