### PR TITLE
Avoid recomputing text embeddings for custom labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ df = pd.DataFrame(predictions)
 ```python
 from bioclip import CustomLabelsClassifier
 
-classifier = CustomLabelsClassifier()
-predictions = classifier.predict("Ursus-arctos.jpeg", ["duck","fish","bear"])
+classifier = CustomLabelsClassifier(["duck","fish","bear"])
+predictions = classifier.predict("Ursus-arctos.jpeg")
 for prediction in predictions:
    print(prediction["classification"], prediction["score"])
 ```

--- a/src/bioclip/__main__.py
+++ b/src/bioclip/__main__.py
@@ -31,10 +31,10 @@ def write_results_to_file(df, format, outfile):
 def predict(image_file: list[str], format: str,  output: str,
              cls_str: str, device: str,  rank: Rank, k: int):
     if cls_str:
-        classifier = CustomLabelsClassifier(device=device)
+        classifier = CustomLabelsClassifier(cls_ary=cls_str.split(','), device=device)
         data = []
         for image_path in image_file:
-            data.extend(classifier.predict(image_path=image_path, cls_ary=cls_str.split(',')))
+            data.extend(classifier.predict(image_path=image_path))
         write_results(data, format, output)
     else:
         classifier = TreeOfLifeClassifier(device=device)

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -45,8 +45,8 @@ class TestPredict(unittest.TestCase):
         self.assertEqual(prediction_ary[0], prediction_dict)
 
     def test_custom_labels_classifier(self):
-        classifier = CustomLabelsClassifier()
-        results = classifier.predict(image_path=EXAMPLE_CAT_IMAGE, cls_ary=['cat', 'dog'])
+        classifier = CustomLabelsClassifier(cls_ary=['cat', 'dog'])
+        results = classifier.predict(image_path=EXAMPLE_CAT_IMAGE)
         self.assertEqual(results, [
             {'file_name': EXAMPLE_CAT_IMAGE, 'classification': 'cat', 'score': unittest.mock.ANY},
             {'file_name': EXAMPLE_CAT_IMAGE, 'classification': 'dog', 'score': unittest.mock.ANY},


### PR DESCRIPTION
When creating predictions for a custom class list the text embeddings were recreated for every image.

Fixes #15