### PR TITLE
Display help menus more promptly

### DIFF
--- a/src/bioclip/__init__.py
+++ b/src/bioclip/__init__.py
@@ -1,6 +1,16 @@
 # SPDX-FileCopyrightText: 2024-present John Bradley <johnbradley2008@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-from bioclip.predict import TreeOfLifeClassifier, Rank, CustomLabelsClassifier, CustomLabelsBinningClassifier
 
 __all__ = ["TreeOfLifeClassifier", "Rank", "CustomLabelsClassifier", "CustomLabelsBinningClassifier"]
+
+def __getattr__(name):
+    if name in __all__:
+        from bioclip.predict import (
+            TreeOfLifeClassifier,
+            Rank,
+            CustomLabelsClassifier,
+            CustomLabelsBinningClassifier,
+        )
+        return locals()[name]
+    raise AttributeError(f"module {__name__} has no attribute {name}")


### PR DESCRIPTION
Addresses #57 (speed up help menu displays by deferring large imports until called for to execute a command).

For a brief demo of the quality of life improvement, timing runs on my laptop for displaying help menus before and after the lazy loading are shown below. 

Eager loading, fresh environment:
```
$ time bioclip -h
usage: bioclip [-h] {predict,embed,list-models} ...

BioCLIP command line interface

options:
  -h, --help            show this help message and exit

commands:
  {predict,embed,list-models}
    predict             Use BioCLIP to generate predictions for image files.
    embed               Use BioCLIP to generate embeddings for image files.
    list-models         List available models and pretrained model checkpoints.

real    0m18.306s
user    0m0.000s
sys     0m0.062s
```

Eager loading, subsequently in the same environment:
```
$ time bioclip -h
usage: bioclip [-h] {predict,embed,list-models} ...

BioCLIP command line interface

options:
  -h, --help            show this help message and exit

commands:
  {predict,embed,list-models}
    predict             Use BioCLIP to generate predictions for image files.
    embed               Use BioCLIP to generate embeddings for image files.
    list-models         List available models and pretrained model checkpoints.

real    0m4.203s
user    0m0.000s
sys     0m0.047s
```

Lazy loading, fresh environment:
```
$ time bioclip -h
usage: bioclip [-h] {predict,embed,list-models} ...

BioCLIP command line interface

options:
  -h, --help            show this help message and exit
 
commands:
  {predict,embed,list-models}
    predict             Use BioCLIP to generate predictions for image files.
    embed               Use BioCLIP to generate embeddings for image files.
    list-models         List available models and pretrained model checkpoints.

real    0m2.612s
user    0m0.000s
sys     0m0.031s
```
Lazy loading, subsequently in the same environment:
```
$ time bioclip -h
usage: bioclip [-h] {predict,embed,list-models} ...

BioCLIP command line interface

options:
  -h, --help            show this help message and exit

commands:
  {predict,embed,list-models}
    predict             Use BioCLIP to generate predictions for image files.
    embed               Use BioCLIP to generate embeddings for image files.
    list-models         List available models and pretrained model checkpoints.

real    0m0.604s
user    0m0.000s
sys     0m0.046s
```

Similarly for sub-command menus.