### PR TITLE
Add --subset argument to predict command

### DIFF
--- a/docs/command-line-help.md
+++ b/docs/command-line-help.md
@@ -1,11 +1,12 @@
 # Command Line Help
 
 ## bioclip predict
+Use BioCLIP to generate predictions for image files.
 ```
-usage: bioclip predict [-h] [--format {table,csv}] [--output OUTPUT] 
+usage: bioclip predict [-h] [--format {table,csv}] [--output OUTPUT]
                        [--rank {kingdom,phylum,class,order,family,genus,species} |
-                       --cls CLS | --bins BINS] [--k K] [--device DEVICE]
-                       [--model MODEL] [--pretrained PRETRAINED]
+                        --cls CLS | --bins BINS | --subset SUBSET] [--k K]
+                       [--device DEVICE] [--model MODEL] [--pretrained PRETRAINED]
                        image_file [image_file ...]
 
 positional arguments:
@@ -16,13 +17,21 @@ options:
   --format {table,csv}  format of the output, default: csv
   --output OUTPUT       print output to file, default: stdout
   --rank {kingdom,phylum,class,order,family,genus,species}
-                        rank of the classification, default: species (when)
+                        rank of the classification, default: species, when
+                        specified the --cls, --bins, and --subset arguments
+                        are not allowed.
   --cls CLS             classes to predict: either a comma separated list or a
                         path to a text file of classes (one per line), when
-                        specified the --rank and --bins arguments are not allowed.
+                        specified the --rank, --bins, and --subset arguments
+                        are not allowed.
   --bins BINS           path to CSV file with two columns with the first being
                         classes and second being bin names, when specified the
-                        --cls argument is not allowed.
+                        --rank, --cls, and --subset arguments are not allowed.
+  --subset SUBSET       path to CSV file used to subset the tree of life
+                        embeddings. CSV first column must be named one of
+                        kingdom,phylum,class,order,family,genus,species. When
+                        specified the --rank, --bins, and --cls arguments are
+                        not allowed.
   --k K                 number of top predictions to show, default: 5
   --device DEVICE       device to use (cpu or cuda or mps), default: cpu
   --model MODEL         model identifier (see command list-models);
@@ -33,8 +42,8 @@ options:
                         (see command list-models)
 ```
 
-
 ## bioclip embed
+Use BioCLIP to generate embeddings for image files.
 ```
 usage: bioclip embed [-h] [--output OUTPUT] [--device DEVICE] [--model MODEL]
                      [--pretrained PRETRAINED] image_file [image_file ...]
@@ -55,6 +64,7 @@ options:
 ```
 
 ## bioclip list-models
+List available models and pretrained model checkpoints.
 ```
 usage: bioclip list-models [-h] [--model MODEL]
 
@@ -67,4 +77,13 @@ options:
   -h, --help     show this help message and exit
   --model MODEL  list available tags for pretrained model checkpoint(s) for
                  specified model
+```
+
+## bioclip list-tol-taxa
+Print a CSV of the taxa embedding labels included with the tree of life model to the terminal.
+```
+usage: bioclip list-tol-taxa [-h]
+
+options:
+  -h, --help  show this help message and exit
 ```

--- a/docs/command-line-tutorial.md
+++ b/docs/command-line-tutorial.md
@@ -67,6 +67,34 @@ Output:
 !!! info "Documentation"
     The [bioclip predict documentation](command-line-help.md/#bioclip-predict) describes all arguments supported by `bioclip predict` command.
 
+### Predict using a TOL subset
+The `predict` command has support for a `--subset <csv-path>` argument. The first column in the CSV file must be named kingdom, phylum, class, order, family, genus, or species. The values must match the TOL labels otherwise an error occurs. See the [bioclip list-tol-taxa](command-line-help.md/#bioclip-list-tol-taxa) command to create a CSV of TOL labels.
+
+In this example we create a CSV to subset TOL to two orders.
+Create a CSV named `orders.csv` with the following content:
+```
+order
+Artiodactyla
+Rodentia
+```
+
+```console
+bioclip predict --subset orders.csv Ursus-arctos.jpeg
+```
+
+Output:
+```
+file_name,kingdom,phylum,class,order,family,genus,species_epithet,species,common_name,score
+Ursus-arctos.jpeg,Animalia,Chordata,Mammalia,Artiodactyla,Cervidae,Cervus,canadensis sibericus,Cervus canadensis sibericus,,0.7347981333732605
+Ursus-arctos.jpeg,Animalia,Chordata,Mammalia,Artiodactyla,Cervidae,Alces,alces,Alces alces,European elk,0.17302176356315613
+...
+```
+
+!!! info "Documentation"
+    The [bioclip predict documentation](command-line-help.md/#bioclip-predict) describes all arguments supported by `bioclip predict` command.
+
+
+
 ## Custom Label Predictions
 To predict with custom labels using the `bioclip predict` command the `--cls` or `--bins` arguments must be used.
 

--- a/src/bioclip/__main__.py
+++ b/src/bioclip/__main__.py
@@ -152,6 +152,9 @@ def create_classes_str(cls_file_path):
 
 
 def main():
+    # Prevent UnicodeEncodeError on Windows
+    if sys.platform == 'win32':
+        sys.stdout.reconfigure(encoding='utf-8')
     args = parse_args()
     if args.command == 'embed':
         embed(args.image_file,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -33,6 +33,11 @@ class TestParser(unittest.TestCase):
         self.assertEqual(args.k, 10)
         self.assertEqual(args.cls, None)
         self.assertEqual(args.device, 'cuda')
+        self.assertEqual(args.subset, None)
+
+        # test tree of life subset
+        args = parse_args(['predict', 'image.jpg', '--subset', 'somefile.csv'])
+        self.assertEqual(args.subset, 'somefile.csv')
 
         # test custom class list version of predict
         args = parse_args(['predict', 'image.jpg', '--format', 'table', '--output', 'output.csv', '--cls', 'class1,class2', '--device', 'cuda'])
@@ -70,6 +75,19 @@ class TestParser(unittest.TestCase):
         args = parse_args(['predict', 'image.jpg', '--cls', 'class1,class2', '--k', '10'])
         self.assertEqual(args.k, 10)
 
+        # test error when using --cls with --subset
+        with self.assertRaises(SystemExit):
+            parse_args(['predict', 'image.jpg', '--cls', 'class1,class2', '--subset', 'somefile.cvs'])
+
+        # test error when using --bins with --subset
+        with self.assertRaises(SystemExit):
+            parse_args(['predict', 'image.jpg', '--bins', 'somefile.csv', '--subset', 'somefile.cvs'])
+
+        # test error when using --rank with --subset
+        with self.assertRaises(SystemExit):
+            parse_args(['predict', 'image.jpg', '--rank', 'class', '--subset', 'somefile.cvs'])
+
+
         # example showing filename
         args = parse_args(['predict', 'image.jpg', '--cls', 'classes.txt', '--k', '10'])
         self.assertEqual(args.cls, 'classes.txt')
@@ -86,6 +104,9 @@ class TestParser(unittest.TestCase):
         self.assertEqual(args.output, 'data.json')
         self.assertEqual(args.device, 'cuda')
 
+        args = parse_args(['list-tol-taxa'])
+        self.assertEqual(args.command, 'list-tol-taxa')
+
     def test_create_classes_str(self):
         data = "class1\nclass2\nclass3"
         with patch("builtins.open", mock_open(read_data=data)) as mock_file:
@@ -96,10 +117,11 @@ class TestParser(unittest.TestCase):
     def test_predict_no_class(self, mock_parse_args, mock_predict):
         mock_parse_args.return_value = argparse.Namespace(command='predict', image_file='image.jpg', format='csv',
                                                           output='stdout', rank=Rank.SPECIES, k=5, cls=None, device='cpu',
-                                                          model=None, pretrained=None, bins=None)
+                                                          model=None, pretrained=None, bins=None, subset=None)
         main()
         mock_predict.assert_called_with('image.jpg', format='csv', output='stdout', cls_str=None, rank=Rank.SPECIES,
-                                        bins_path=None, k=5, device='cpu', model_str=None, pretrained_str=None)
+                                        bins_path=None, k=5, device='cpu', model_str=None, pretrained_str=None,
+                                        subset=None)
 
     @patch('bioclip.__main__.predict')
     @patch('bioclip.__main__.parse_args')
@@ -108,10 +130,12 @@ class TestParser(unittest.TestCase):
         mock_os.path.exists.return_value = False
         mock_parse_args.return_value = argparse.Namespace(command='predict', image_file='image.jpg', format='csv',
                                                           output='stdout', rank=Rank.SPECIES, k=5, cls='dog,fish,bird',
-                                                          device='cpu', model=None, pretrained=None, bins=None)
+                                                          device='cpu', model=None, pretrained=None, bins=None,
+                                                          subset=None)
         main()
         mock_predict.assert_called_with('image.jpg', format='csv', output='stdout', cls_str='dog,fish,bird', rank=Rank.SPECIES,
-                                        bins_path=None, k=5, device='cpu', model_str=None, pretrained_str=None)
+                                        bins_path=None, k=5, device='cpu', model_str=None, pretrained_str=None,
+                                        subset=None)
 
     @patch('bioclip.__main__.predict')
     @patch('bioclip.__main__.parse_args')
@@ -120,11 +144,13 @@ class TestParser(unittest.TestCase):
         mock_os.path.exists.return_value = True
         mock_parse_args.return_value = argparse.Namespace(command='predict', image_file='image.jpg', format='csv', 
                                                           output='stdout', rank=Rank.SPECIES, k=5, cls='somefile.txt',
-                                                          device='cpu', model=None, pretrained=None, bins=None)
+                                                          device='cpu', model=None, pretrained=None, bins=None,
+                                                          subset=None)
         with patch("builtins.open", mock_open(read_data='dog\nfish\nbird')) as mock_file:
             main()
         mock_predict.assert_called_with('image.jpg', format='csv', output='stdout', cls_str='dog,fish,bird', rank=Rank.SPECIES,
-                                        bins_path=None, k=5, device='cpu', model_str=None, pretrained_str=None)
+                                        bins_path=None, k=5, device='cpu', model_str=None, pretrained_str=None,
+                                        subset=None)
 
     @patch('bioclip.__main__.predict')
     @patch('bioclip.__main__.parse_args')
@@ -134,11 +160,27 @@ class TestParser(unittest.TestCase):
         mock_parse_args.return_value = argparse.Namespace(command='predict', image_file='image.jpg', format='csv', 
                                                           output='stdout', rank=None, k=5, cls=None, 
                                                           device='cpu', model=None, pretrained=None,
-                                                          bins='some.csv')
+                                                          bins='some.csv', subset=None)
         with patch("builtins.open", mock_open(read_data='dog\nfish\nbird')) as mock_file:
             main()
         mock_predict.assert_called_with('image.jpg', format='csv', output='stdout', cls_str=None, rank=None,
-                                        bins_path='some.csv', k=5, device='cpu', model_str=None, pretrained_str=None)
+                                        bins_path='some.csv', k=5, device='cpu', model_str=None,
+                                        pretrained_str=None, subset=None)
+
+    @patch('bioclip.__main__.predict')
+    @patch('bioclip.__main__.parse_args')
+    @patch('bioclip.__main__.os')
+    def test_predict_subset(self, mock_os, mock_parse_args, mock_predict):
+        mock_os.path.exists.return_value = True
+        mock_parse_args.return_value = argparse.Namespace(command='predict', image_file='image.jpg', format='csv',
+                                                          output='stdout', rank=None, k=5, cls=None,
+                                                          device='cpu', model=None, pretrained=None,
+                                                          bins=None, subset='somefile.csv')
+        main()
+        mock_predict.assert_called_with('image.jpg', format='csv', output='stdout', cls_str=None, rank=None,
+                                        bins_path=None, k=5, device='cpu', model_str=None,
+                                        pretrained_str=None, subset='somefile.csv')
+
     @patch('bioclip.__main__.os.path')
     def test_parse_bins_csv_file_missing(self, mock_path):
         mock_path.exists.return_value = False


### PR DESCRIPTION
Adds a `--subset <csv-file>` argument that will filter the TOL embeddings. The CSV file first column must be named for a taxa rank: 'kingdom','phylum','class','order','family','genus', or 'species'. All values must map to taxa values known by TOL or an error will be raised.

See #56 for reference.