### PR TITLE
Fix .zenodo.json and add test

### DIFF
--- a/.github/workflows/validate-zenodo.yml
+++ b/.github/workflows/validate-zenodo.yml
@@ -1,0 +1,19 @@
+name: Check zenodo metadata
+
+on: [push]
+
+jobs:
+  check-zenodo-metadata:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Install dependencies
+        run: npm install zenodraft@0.14.1
+      - name: Check .zenodo.json file
+        run: |
+          npx zenodraft metadata validate .zenodo.json 

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -42,52 +42,13 @@
   "publication_date": "2024-12-09",
   "title": "pybioclip",
   "version": "1.2.0",
-  "funding": [
-      {
-        "award": {
-          "id": "021nxhr62::2118240",
-          "number": "2118240",
-          "program": "CISE/OAD",
-          "title": {
-            "en": "HDR Institute: Imageomics: A New Frontier of Biological Information Powered by Knowledge-Guided Machine Learning"
-          }
-        },
-        "funder": {
-          "id": "021nxhr62",
-          "name": "National Science Foundation"
+  "grants": [
+        {
+            "id": "021nxhr62::2118240"
         }
-      }
     ],
     "references": [
-      {
-         "reference": "Stevens S, Wu J, Thompson MJ, Campolongo EG, Song CH, Carlyn DE, Dong L, Dahdul WM, Stewart C, Berger-Wolf T, Chao W-L, Su Y (2024) BioCLIP: A Vision Foundation Model for the Tree of Life. Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR), 19412\u201319424."
-      }
-    ],
-    "related_identifiers": [
-      {
-        "identifier": "https://github.com/Imageomics/pybioclip/",
-        "relation_type": {
-          "id": "isversionof",
-          "title": {
-            "de": "Ist eine Version von",
-            "en": "Is version of"
-          }
-        },
-        "resource_type": {
-          "id": "software",
-          "title": {
-            "de": "Software",
-            "en": "Software"
-          }
-        },
-        "scheme": "url"
-      }
-    ],
-    "resource_type": {
-      "id": "software",
-      "title": {
-        "de": "Software",
-        "en": "Software"
-      }
-    }
+        "Stevens S, Wu J, Thompson MJ, Campolongo EG, Song CH, Carlyn DE, Dong L, Dahdul WM, Stewart C, Berger-Wolf T, Chao W-L, Su Y (2024) BioCLIP: A Vision Foundation Model for the Tree of Life. Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR), 19412\u201319424."
+    ]
 }
+


### PR DESCRIPTION
Updates zenodo metadata based on zenodraft:
1. Fixes references to be a list of strings
2. Removes resource_type and related_identifiers These raised errors and do not seem to have an effect. Zenodo already knows this is software.
3. Replaces "funding" that had no effect in zenodo for "grants" that does.

Adds github action that will validate .zenodo.json using https://github.com/zenodraft/zenodraft.

Fixes #74