### PR TITLE
Fix grouping performance bug

### DIFF
--- a/src/bioclip/predict.py
+++ b/src/bioclip/predict.py
@@ -575,10 +575,11 @@ class TreeOfLifeClassifier(BaseClassifier):
         result = []
         for i, image in enumerate(images):
             key = self.make_key(image, i)
+            image_probs = probs[key].cpu()
             if rank == Rank.SPECIES:
-                result.extend(self.format_species_probs(key, probs[key], k))
+                result.extend(self.format_species_probs(key, image_probs, k))
             else:
-                result.extend(self.format_grouped_probs(key, probs[key], rank, min_prob, k))
+                result.extend(self.format_grouped_probs(key, image_probs, rank, min_prob, k))
         return result
 
 


### PR DESCRIPTION
Ensures that probabilities are moved to the cpu before appling grouping logic to avoid performance issues moving data from CUDA/MPS -> CPU again and again.

Fixes #84