### PR TITLE
Fix pil batching bug

### DIFF
--- a/src/bioclip/predict.py
+++ b/src/bioclip/predict.py
@@ -243,8 +243,8 @@ class BaseClassifier(nn.Module):
         return F.softmax(logits, dim=1)
 
     def create_probabilities_for_images(self, images: List[str] | List[PIL.Image.Image],
+                                        keys: List[str],
                                         txt_features: torch.Tensor) -> dict[str, torch.Tensor]:
-        keys = [self.make_key(image, i) for i,image in enumerate(images)]
         images = [self.ensure_rgb_image(image) for image in images]
         img_features = self.create_image_features(images)
         probs = self.create_probabilities(img_features, txt_features)
@@ -258,12 +258,14 @@ class BaseClassifier(nn.Module):
                                                 batch_size: int | None) -> dict[str, torch.Tensor]:
         if not batch_size:
             batch_size = len(images)
+        keys = [self.make_key(image, i) for i,image in enumerate(images)]
         result = {}
         total_images = len(images)
         with tqdm(total=total_images, unit="images") as progress_bar:
             for i in range(0, len(images), batch_size):
                 grouped_images = images[i:i + batch_size]
-                probs = self.create_probabilities_for_images(grouped_images, txt_features)
+                grouped_keys = keys[i:i + batch_size]
+                probs = self.create_probabilities_for_images(grouped_images, grouped_keys, txt_features)
                 result.update(probs)
                 progress_bar.update(len(grouped_images))
         return result

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -52,6 +52,21 @@ class TestPredict(unittest.TestCase):
                                             rank=Rank.SPECIES)
         self.assertEqual(len(prediction_ary), 10)
 
+    def test_tree_of_life_classifier_multiple_pil_batching(self):
+        classifier = TreeOfLifeClassifier()
+        img1 = PIL.Image.open(EXAMPLE_CAT_IMAGE)
+        img2 = PIL.Image.open(EXAMPLE_CAT_IMAGE2)
+
+        prediction_ary = classifier.predict(images=[img1, img2],
+                                            rank=Rank.SPECIES,
+                                            batch_size=1)
+
+        self.assertEqual(len(prediction_ary), 10)
+        for i in range(0, 5):
+            self.assertEqual(prediction_ary[i]['file_name'], '0')
+        for i in range(5, 10):
+            self.assertEqual(prediction_ary[i]['file_name'], '1')
+
     def test_tree_of_life_classifier_family(self):
         classifier = TreeOfLifeClassifier()
         prediction_ary = classifier.predict(images=[EXAMPLE_CAT_IMAGE], rank=Rank.FAMILY, k=2)


### PR DESCRIPTION
Fixes a bug related to predicting more than batch_size pil images. The code assigns a key to each prediction based on the index of the pil image (since it has no filename). The batching logic did not properly take this into account.

Fixes #93