### PR TITLE
Fix mkdocs generation - python version

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.x'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Upgrades to the latest version of python when building documentation following the convention from publish-to-pypi.yml.

Fixes #102