### PR TITLE
Switch to bioclip-2 model

### DIFF
--- a/docs/command-line-help.md
+++ b/docs/command-line-help.md
@@ -36,7 +36,7 @@ options:
   --k K                 number of top predictions to show, default: 5
   --device DEVICE       device to use (cpu or cuda or mps), default: cpu
   --model MODEL         model identifier (see command list-models);
-                        default: hf-hub:imageomics/bioclip
+                        default: hf-hub:imageomics/bioclip-2
   --pretrained PRETRAINED
                         pretrained model checkpoint as tag or file, depends on
                         model; needed only if more than one is available
@@ -59,7 +59,7 @@ options:
   --output OUTPUT       print output to file, default: stdout
   --device DEVICE       device to use (cpu or cuda or mps), default: cpu
   --model MODEL         model identifier (see command list-models);
-                        default: hf-hub:imageomics/bioclip
+                        default: hf-hub:imageomics/bioclip-2
   --pretrained PRETRAINED
                         pretrained model checkpoint as tag or file, depends
                         on model; needed only if more than one is available
@@ -74,7 +74,7 @@ usage: bioclip list-models [-h] [--model MODEL]
 Note that this will only list models known to open_clip; any model identifier
 loadable by open_clip, such as from hf-hub, file, etc should also be usable for
 --model in the embed and predict commands.
-(The default model hf-hub:imageomics/bioclip is one example.)
+(The default model hf-hub:imageomics/bioclip-2 is one example.)
 
 options:
   -h, --help     show this help message and exit

--- a/docs/command-line-tutorial.md
+++ b/docs/command-line-tutorial.md
@@ -4,7 +4,7 @@ Before beginning this tutorial you need to [install pybioclip](index.md#installa
 and [`Felis-catus.jpeg`](https://huggingface.co/spaces/imageomics/bioclip-demo/blob/ef075807a55687b320427196ac1662b9383f988f/examples/Felis-catus.jpeg).
 
 ## Tree Of Life Predictions
-The `bioclip predict` command, when not supplying a custom list of labels, will create a prediction based on the [BioCLIP tree of life embeddings](https://huggingface.co/spaces/imageomics/bioclip-demo/blob/main/txt_emb_species.npy).
+The `bioclip predict` command, when not supplying a custom list of labels, will create a prediction based on the [BioCLIP 2 TreeOfLife-200M embeddings](https://huggingface.co/datasets/imageomics/TreeOfLife-200M/tree/main/embeddings).
 
 ### Predict species for an image
 
@@ -92,6 +92,15 @@ Ursus-arctos.jpeg,Animalia,Chordata,Mammalia,Artiodactyla,Cervidae,Alces,alces,A
 !!! info "Documentation"
     The [bioclip predict documentation](command-line-help.md/#bioclip-predict) describes all arguments supported by `bioclip predict` command.
 
+### Use Original BioCLIP Model
+By default the [BioCLIP 2](https://huggingface.co/imageomics/bioclip-2) model is used.
+The original [BioCLIP](https://huggingface.co/imageomics/bioclip) model can be used by including a `--model hf-hub:imageomics/bioclip` argument for either the `predict` or `embed` commands.
+Example:
+```console
+bioclip predict --model hf-hub:imageomics/bioclip Ursus-arctos.jpeg
+```
+
+When using the original BioCLIP model for TreeOfLife predictions the [TreeOfLife-10M embeddings](https://huggingface.co/datasets/imageomics/TreeOfLife-10M/tree/main/embeddings) are used.
 
 
 ## Custom Label Predictions
@@ -181,7 +190,7 @@ bioclip embed Ursus-arctos.jpeg
 Output:
 ```
 {
-    "model": "hf-hub:imageomics/bioclip",
+    "model": "hf-hub:imageomics/bioclip-2",
     "embeddings": {
         "Ursus-arctos.jpeg": [
             -0.23633578419685364,
@@ -194,6 +203,7 @@ Output:
 ```
 !!! info "Documentation"
     The [bioclip embed documentation](command-line-help.md/#bioclip-embed) describes all arguments supported by `bioclip embed` command.
+
 
 ## View command line help
 ```console

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,7 @@
 # pybioclip
 
-Command line tool and python package to simplify the use of [BioCLIP](https://imageomics.github.io/bioclip/).
+Command line tool and python package to simplify the use of [BioCLIP](https://imageomics.github.io/bioclip/) and 
+[BioCLIP 2](https://imageomics.github.io/bioclip-2/) (default).
 
 Key features include:
 

--- a/docs/python-tutorial.md
+++ b/docs/python-tutorial.md
@@ -40,6 +40,10 @@ Output from the `predict()` method showing the dictionary structure:
 }]
 ```
 
+!!! info "Model and Embedding config"
+    By default the predictions use the [BioCLIP 2 model](https://huggingface.co/imageomics/bioclip-2) in combination with its [TreeOfLife-200M embeddings](https://huggingface.co/datasets/imageomics/TreeOfLife-200M/tree/main/embeddings). By setting the `model_str` parameter to `bioclip.BIOCLIP_V1_MODEL_STR` the original BioCLIP model will be used in combination with its [TreeOfLife-10M embeddings](https://huggingface.co/datasets/imageomics/TreeOfLife-10M/tree/main/embeddings).
+
+
 The output from the predict function can be converted into a [pandas DataFrame](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html) like so:
 ```python
 import pandas as pd
@@ -84,6 +88,17 @@ classifier = CustomLabelsClassifier(
     cls_ary = ["duck","fish","bear"],
     model_str='ViT-B-16',
     pretrained_str='laion2b_s34b_b88k')
+
+print(classifier.predict("Ursus-arctos.jpeg"))
+```
+
+### Predict with the original BioCLIP model
+```python
+from bioclip import CustomLabelsClassifier, BIOCLIP_V1_MODEL_STR
+
+classifier = CustomLabelsClassifier(
+    cls_ary = ["duck","fish","bear"],
+    model_str=BIOCLIP_V1_MODEL_STR)
 
 print(classifier.predict("Ursus-arctos.jpeg"))
 ```

--- a/src/bioclip/__init__.py
+++ b/src/bioclip/__init__.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2024-present John Bradley <johnbradley2008@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-from bioclip.predict import TreeOfLifeClassifier, Rank, CustomLabelsClassifier, CustomLabelsBinningClassifier
+from bioclip.predict import TreeOfLifeClassifier, Rank, CustomLabelsClassifier, CustomLabelsBinningClassifier, BIOCLIP_MODEL_STR, BIOCLIP_V2_MODEL_STR, BIOCLIP_V1_MODEL_STR
 
-__all__ = ["TreeOfLifeClassifier", "Rank", "CustomLabelsClassifier", "CustomLabelsBinningClassifier"]
+__all__ = ["TreeOfLifeClassifier", "Rank", "CustomLabelsClassifier", "CustomLabelsBinningClassifier", "BIOCLIP_MODEL_STR", "BIOCLIP_V2_MODEL_STR", "BIOCLIP_V1_MODEL_STR"]

--- a/src/bioclip/__main__.py
+++ b/src/bioclip/__main__.py
@@ -1,5 +1,5 @@
 from bioclip import TreeOfLifeClassifier, Rank, CustomLabelsClassifier, CustomLabelsBinningClassifier
-from .predict import BIOCLIP_MODEL_STR, get_rank_labels
+from .predict import BIOCLIP_MODEL_STR, TOL_MODELS, ensure_tol_supported_model, get_rank_labels
 import open_clip as oc
 import os
 import json
@@ -148,8 +148,10 @@ def parse_args(input_args=None):
     if args.command == 'predict':
         if not args.cls and not args.bins:
             # tree of life class list mode
-            if args.model or args.pretrained:
-                raise ValueError("Custom model or checkpoints currently not supported for Tree-of-Life prediction")
+            if args.pretrained:
+                raise ValueError("Custom checkpoints are currently not supported for TreeOfLife prediction")
+            if args.model:
+                ensure_tol_supported_model(args.model)
             if not args.rank:
                 args.rank = 'species'
             args.rank = Rank[args.rank.upper()]
@@ -197,7 +199,7 @@ def main():
             for tag in oc.list_pretrained_tags_by_model(args.model):
                 print(tag)
         else:
-            for model_str in oc.list_models():
+            for model_str in list(TOL_MODELS.keys()) + oc.list_models():
                 print(f"\t{model_str}")
     elif args.command == 'list-tol-taxa':
         classifier = TreeOfLifeClassifier()


### PR DESCRIPTION
Changes default model to bioclip-2. The bioclip v1 model can still be used by specifying model as 'hf-hub:imageomics/bioclip'.

Made tests more generic to better handle model differences.

Fixes #111