### PR TITLE
Add option to record prediction logs

### DIFF
--- a/docs/command-line-help.md
+++ b/docs/command-line-help.md
@@ -43,6 +43,11 @@ options:
                         (see command list-models)
   --batch-size BATCH_SIZE
                         Number of images to process in a batch, default: 10
+  --log LOG_FILE        Path to a file for recording prediction logs.
+                        If the file extension is '.json', the log is written
+                        in JSON for building a provenance chain; otherwise, 
+                        logs are appended in a human-readable text format.
+                        If not specified, no log is written.
 ```
 
 ## bioclip embed

--- a/docs/command-line-tutorial.md
+++ b/docs/command-line-tutorial.md
@@ -103,6 +103,46 @@ bioclip predict --model hf-hub:imageomics/bioclip Ursus-arctos.jpeg
 When using the original BioCLIP model for TreeOfLife predictions the [TreeOfLife-10M embeddings](https://huggingface.co/datasets/imageomics/TreeOfLife-10M/tree/main/embeddings) are used.
 
 
+### Save a prediction log
+The `predict` command supports a `--log <path>` argument to save prediction details to a file.
+If the file extension is '.json', the log is written in JSON for building a provenance chain; otherwise,
+logs are appended in a human-readable text format. By default no log is written.
+
+Example usage:
+```console
+bioclip predict --log bioclip.json Ursus-arctos.jpeg
+```
+
+The resulting `bioclip.json` will contain structured information similar to:
+```json
+{
+    "pybioclip_version": "1.3.3",
+    "start": "2025-07-08T16:25:11",
+    "end": "2025-07-08T16:25:13",
+    "command_line": "bioclip predict --log bioclip.json Ursus-arctos.jpeg",
+    "model": "hf-hub:imageomics/bioclip-2",
+    "pretrained": null,
+    "device": "cpu",
+    "top_level_settings": {
+        "tree_of_life_version": "imageomics/TreeOfLife-200M",
+        "subset": null
+    },
+    "predictions": [
+        {
+            "images": [
+                "Ursus-arctos.jpeg"
+            ],
+            "details": {
+                "rank": "species",
+                "min_prob": 1e-09,
+                "k": 5,
+                "batch_size": 10
+            }
+        }
+    ]
+}
+```
+
 ## Custom Label Predictions
 To predict with custom labels using the `bioclip predict` command the `--cls` or `--bins` arguments must be used.
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -39,3 +39,10 @@
 ::: bioclip.predict.BaseClassifier
     options:
       show_root_heading: true
+
+::: bioclip.recorder
+    options:
+      show_root_heading: true
+      members:
+      - attach_prediction_recorder
+      - save_recorded_predictions

--- a/src/bioclip/recorder.py
+++ b/src/bioclip/recorder.py
@@ -1,0 +1,183 @@
+"""Records predictions made by a classifier and saves the output to a file."""
+from .__about__ import __version__ as pybioclip_version
+from datetime import datetime
+from typing import Union
+import sys
+import json
+import os
+
+
+def is_json_file(path: str) -> bool:
+    return path.endswith(".json")
+
+
+def verify_recorder_path(path: str):
+    """
+    Ensure the path can either be appended to or is a non-existent JSON file.
+    """
+    if is_json_file(path):
+        if os.path.exists(path):
+            raise ValueError(f"File {path} already exists. Please choose a different file name.")
+    else:
+        return True
+
+
+def attach_prediction_recorder(classifier: object, **top_level_settings):
+    """
+    Attach a PredictionRecorder to the classifier instance that will record metadata and subsequent predictions.
+    Call save_recorded_predictions to save the recorded predictions to a file.
+
+    Args:
+        classifier (object): The classifier (such as TreeOfLifeClassifier) instance to attach the recorder to.
+        **top_level_settings: Additional settings to be recorded.
+
+    Returns:
+        PredictionRecorder: An instance of PredictionRecorder attached to the classifier.
+    """
+    recorder = PredictionRecorder(classifier, **top_level_settings)
+    classifier.set_recorder(recorder)
+    return recorder
+
+
+def save_recorded_predictions(classifier: object, path: str, include_command_line: bool = True):
+    """
+    Saves recorded predictions from the classifier to a file.
+    Before calling this function, ensure that the classifier has a recorder attached
+    using attach_prediction_recorder. Saves the recorder's data to the specified file path in 
+    either JSON or plain text format. If the file extension is '.json', the data is serialized
+    as JSON. Otherwise, the data is appended in a human-readable text format.
+
+    Args:
+        classifier (object): The classifier instance (such as TreeOfLifeClassifier) with recorded predictions.
+        path (str): The file path where the report will be saved.
+        include_command_line (bool): When True includes the python command line in the log file.
+
+    Raises:
+        ValueError: If the output path extension is .json and the file already exists.
+    """
+    if classifier.recorder:
+        command_line = " ".join(sys.argv) if include_command_line else None
+        classifier.recorder.create_report(path, command_line=command_line)
+    else:
+        raise ValueError("The classifier does not have a recorder attached.")
+
+
+class PredictionRecorder:
+    """
+    A class to record predictions made by a classifier.
+    It stores metadata about the model, device, and settings used during the predictions,
+    and allows for the addition of prediction data.
+    The predictions can be saved to a report file.
+    """
+
+    def __init__(self, classifier: object, **top_level_settings):
+        self.model_str = classifier.model_str
+        self.pretrained_str = classifier.pretrained_str
+        self.device = classifier.device
+        self.predictions = []
+        self.top_level_settings = top_level_settings
+        self.start = datetime.now().isoformat(timespec="seconds")
+        self.end = None
+
+    def add_prediction(self, images, **kwargs):
+        """
+        Adds a prediction entry to the recorder.
+        Parameters:
+            images: The images associated with the prediction.
+            **kwargs: Additional details related to the prediction.
+        """
+        self.predictions.append({"images": images, "details": kwargs})
+        self.end = datetime.now().isoformat(timespec="seconds")
+
+    def create_report(self, path: str, command_line: Union[str, None]):
+        """
+        Creates a report of the predictions and saves it to the specified path.
+
+        Args:
+            path (str): The file path where the report will be saved.
+            command_line (str): The command line used to run the predictions.
+        """
+        report = PredictionLogReport(self, command_line)
+        report.save(path)
+
+
+class PredictionLogReport:
+    """
+    A class to generate a report of the predictions made by the PredictionRecorder.
+    The report includes metadata about the model, device, and settings used during the predictions.
+    """
+
+    def __init__(self, recorder: PredictionRecorder, command_line: Union[str, None]):
+        self.recorder = recorder
+        self.start = recorder.start
+        self.end = recorder.end
+        self.command_line = command_line
+
+    def create_dictionary(self):
+        """
+        Creates a dictionary representation of the report.
+
+        Returns:
+            dict: A dictionary containing the report data.
+        """
+        return {
+            "pybioclip_version": pybioclip_version,
+            "start": self.start,
+            "end": self.end,
+            "command_line": self.command_line,
+            "model": self.recorder.model_str,
+            "pretrained": self.recorder.pretrained_str,
+            "device": self.recorder.device,
+            "top_level_settings": self.recorder.top_level_settings,
+            "predictions": self.recorder.predictions
+        }
+
+    @staticmethod
+    def format_key(key):
+        return " ".join([word.capitalize() for word in key.split("_")])
+
+    def _add_title(self, f):
+        title = f"** Prediction Log - pybioclip v{pybioclip_version} - {self.start} to {self.end} **"
+        f.write("*" * len(title) + "\n")
+        f.write(f"{title}\n")
+        f.write("*" * len(title) + "\n")
+
+    def _add_top_level_info(self, f):
+        f.write(f"Model: {self.recorder.model_str}\n")
+        if self.recorder.pretrained_str:
+            f.write(f"Pretrained: {self.recorder.pretrained_str}\n")
+        f.write(f"Device: {self.recorder.device}\n")
+        for k, v in self.recorder.top_level_settings.items():
+            if v is not None:
+                f.write(f"{self.format_key(k)}: {v}\n")
+
+    def _add_predictions(self, f):
+        for pred_dict in self.recorder.predictions:
+            for k, v in pred_dict["details"].items():
+                f.write(f"{self.format_key(k)}: {v}\n")
+            images = pred_dict["images"]
+            f.write("Images:\n" + "\n".join(images) + "\n")
+
+    def save(self, path: str):
+        """
+        Saves the recorder's data to the specified file path in either JSON or plain text format.
+        If the file extension is '.json', the data is serialized as JSON. Otherwise, the data is appended
+        in a human-readable text format.
+        Args:
+            path (str): The file path where the data should be saved.
+        Raises:
+            ValueError: If the output path extension is .json and the file already exists.
+            IOError: If there is an error writing to the file.
+        """
+        verify_recorder_path(path)
+        if is_json_file(path):
+            with open(path, "w") as f:
+                json.dump(self.create_dictionary(), f, indent=4)
+        else:
+            with open(path, "a") as f:
+                self._add_title(f)
+                if self.command_line:
+                    f.write(f"Command Line: {self.command_line}\n")
+                self._add_top_level_info(f)
+                self._add_predictions(f)
+                f.write("\n")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -18,13 +18,15 @@ class TestParser(unittest.TestCase):
         self.assertEqual(args.cls, None)
         self.assertEqual(args.bins, None)
         self.assertEqual(args.device, 'cpu')
+        self.assertEqual(args.log, None)
 
         args = parse_args(['predict', 'image.jpg', 'image2.png'])
         self.assertEqual(args.command, 'predict')
         self.assertEqual(args.image_file, ['image.jpg', 'image2.png'])
+        self.assertEqual(args.log, None)
 
         # test tree of life version of predict
-        args = parse_args(['predict', 'image.jpg', '--format', 'table', '--output', 'output.csv', '--rank', 'genus', '--k', '10', '--device', 'cuda'])
+        args = parse_args(['predict', 'image.jpg', '--format', 'table', '--output', 'output.csv', '--rank', 'genus', '--k', '10', '--device', 'cuda', '--log', 'log.txt'])
         self.assertEqual(args.command, 'predict')
         self.assertEqual(args.image_file, ['image.jpg'])
         self.assertEqual(args.format, 'table')
@@ -35,14 +37,16 @@ class TestParser(unittest.TestCase):
         self.assertEqual(args.device, 'cuda')
         self.assertEqual(args.subset, None)
         self.assertEqual(args.batch_size, 10)
+        self.assertEqual(args.log, 'log.txt')
 
         # test tree of life subset
-        args = parse_args(['predict', 'image.jpg', '--subset', 'somefile.csv'])
+        args = parse_args(['predict', 'image.jpg', '--subset', 'somefile.csv', '--log', 'log.txt'])
         self.assertEqual(args.subset, 'somefile.csv')
+        self.assertEqual(args.log, 'log.txt')
 
         # test custom class list version of predict
         args = parse_args(['predict', 'image.jpg', '--format', 'table', '--output', 'output.csv',
-                           '--cls', 'class1,class2', '--device', 'cuda', '--batch-size', '5'])
+                           '--cls', 'class1,class2', '--device', 'cuda', '--batch-size', '5', '--log', 'log.txt'])
         self.assertEqual(args.command, 'predict')
         self.assertEqual(args.image_file, ['image.jpg'])
         self.assertEqual(args.format, 'table')
@@ -53,9 +57,10 @@ class TestParser(unittest.TestCase):
         self.assertEqual(args.bins, None)
         self.assertEqual(args.device, 'cuda')
         self.assertEqual(args.batch_size, 5)
+        self.assertEqual(args.log, 'log.txt')
 
         # test binning version of predict
-        args = parse_args(['predict', 'image.jpg', '--format', 'table', '--output', 'output.csv', '--bins', 'bins.csv', '--device', 'cuda'])
+        args = parse_args(['predict', 'image.jpg', '--format', 'table', '--output', 'output.csv', '--bins', 'bins.csv', '--device', 'cuda', '--log', 'log.txt'])
         self.assertEqual(args.command, 'predict')
         self.assertEqual(args.image_file, ['image.jpg'])
         self.assertEqual(args.format, 'table')
@@ -65,6 +70,7 @@ class TestParser(unittest.TestCase):
         self.assertEqual(args.cls, None)
         self.assertEqual(args.bins, 'bins.csv')
         self.assertEqual(args.device, 'cuda')
+        self.assertEqual(args.log, 'log.txt')
 
         # test error when using --cls with --rank
         with self.assertRaises(SystemExit):
@@ -77,6 +83,7 @@ class TestParser(unittest.TestCase):
         # not an error when using --cls with --k
         args = parse_args(['predict', 'image.jpg', '--cls', 'class1,class2', '--k', '10'])
         self.assertEqual(args.k, 10)
+        self.assertEqual(args.log, None)
 
         # test error when using --cls with --subset
         with self.assertRaises(SystemExit):
@@ -90,10 +97,10 @@ class TestParser(unittest.TestCase):
         with self.assertRaises(SystemExit):
             parse_args(['predict', 'image.jpg', '--rank', 'class', '--subset', 'somefile.cvs'])
 
-
         # example showing filename
-        args = parse_args(['predict', 'image.jpg', '--cls', 'classes.txt', '--k', '10'])
+        args = parse_args(['predict', 'image.jpg', '--cls', 'classes.txt', '--k', '10', '--log', 'log.txt'])
         self.assertEqual(args.cls, 'classes.txt')
+        self.assertEqual(args.log, 'log.txt')
 
         args = parse_args(['embed', 'image.jpg'])
         self.assertEqual(args.command, 'embed')
@@ -121,11 +128,11 @@ class TestParser(unittest.TestCase):
         mock_parse_args.return_value = argparse.Namespace(command='predict', image_file='image.jpg', format='csv',
                                                           output='stdout', rank=Rank.SPECIES, k=5, cls=None, device='cpu',
                                                           model=None, pretrained=None, bins=None, subset=None,
-                                                          batch_size=None)
+                                                          batch_size=None, log=None)
         main()
         mock_predict.assert_called_with('image.jpg', format='csv', output='stdout', cls_str=None, rank=Rank.SPECIES,
                                         bins_path=None, k=5, device='cpu', model_str=None, pretrained_str=None,
-                                        subset=None, batch_size=None)
+                                        subset=None, batch_size=None, log=None)
 
     @patch('bioclip.__main__.predict')
     @patch('bioclip.__main__.parse_args')
@@ -135,11 +142,11 @@ class TestParser(unittest.TestCase):
         mock_parse_args.return_value = argparse.Namespace(command='predict', image_file='image.jpg', format='csv',
                                                           output='stdout', rank=Rank.SPECIES, k=5, cls='dog,fish,bird',
                                                           device='cpu', model=None, pretrained=None, bins=None,
-                                                          subset=None, batch_size=None)
+                                                          subset=None, batch_size=None, log=None)
         main()
         mock_predict.assert_called_with('image.jpg', format='csv', output='stdout', cls_str='dog,fish,bird', rank=Rank.SPECIES,
                                         bins_path=None, k=5, device='cpu', model_str=None, pretrained_str=None,
-                                        subset=None, batch_size=None)
+                                        subset=None, batch_size=None, log=None)
 
     @patch('bioclip.__main__.predict')
     @patch('bioclip.__main__.parse_args')
@@ -149,12 +156,12 @@ class TestParser(unittest.TestCase):
         mock_parse_args.return_value = argparse.Namespace(command='predict', image_file='image.jpg', format='csv', 
                                                           output='stdout', rank=Rank.SPECIES, k=5, cls='somefile.txt',
                                                           device='cpu', model=None, pretrained=None, bins=None,
-                                                          subset=None, batch_size=None)
+                                                          subset=None, batch_size=None, log=None)
         with patch("builtins.open", mock_open(read_data='dog\nfish\nbird')) as mock_file:
             main()
         mock_predict.assert_called_with('image.jpg', format='csv', output='stdout', cls_str='dog,fish,bird', rank=Rank.SPECIES,
                                         bins_path=None, k=5, device='cpu', model_str=None, pretrained_str=None,
-                                        subset=None, batch_size=None)
+                                        subset=None, batch_size=None, log=None)
 
     @patch('bioclip.__main__.predict')
     @patch('bioclip.__main__.parse_args')
@@ -165,12 +172,12 @@ class TestParser(unittest.TestCase):
                                                           output='stdout', rank=None, k=5, cls=None, 
                                                           device='cpu', model=None, pretrained=None,
                                                           bins='some.csv', subset=None,
-                                                          batch_size=None)
+                                                          batch_size=None, log=None)
         with patch("builtins.open", mock_open(read_data='dog\nfish\nbird')) as mock_file:
             main()
         mock_predict.assert_called_with('image.jpg', format='csv', output='stdout', cls_str=None, rank=None,
                                         bins_path='some.csv', k=5, device='cpu', model_str=None,
-                                        pretrained_str=None, subset=None, batch_size=None)
+                                        pretrained_str=None, subset=None, batch_size=None, log=None)
 
     @patch('bioclip.__main__.predict')
     @patch('bioclip.__main__.parse_args')
@@ -181,11 +188,11 @@ class TestParser(unittest.TestCase):
                                                           output='stdout', rank=None, k=5, cls=None,
                                                           device='cpu', model=None, pretrained=None,
                                                           bins=None, subset='somefile.csv',
-                                                          batch_size=None)
+                                                          batch_size=None, log=None)
         main()
         mock_predict.assert_called_with('image.jpg', format='csv', output='stdout', cls_str=None, rank=None,
                                         bins_path=None, k=5, device='cpu', model_str=None,
-                                        pretrained_str=None, subset='somefile.csv', batch_size=None)
+                                        pretrained_str=None, subset='somefile.csv', batch_size=None, log=None)
 
     @patch('bioclip.__main__.os.path')
     def test_parse_bins_csv_file_missing(self, mock_path):

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -1,0 +1,174 @@
+import os
+import tempfile
+import unittest
+from bioclip import recorder
+import json
+
+
+class DummyClassifier:
+    def __init__(self, model_str="resnet", pretrained_str="imagenet", device="cpu"):
+        self.model_str = model_str
+        self.pretrained_str = pretrained_str
+        self.device = device
+        self.recorder = None
+
+    def set_recorder(self, rec):
+        self.recorder = rec
+
+
+class TestRecorder(unittest.TestCase):
+    def test_attach_prediction_recorder_sets_recorder(self):
+        clf = DummyClassifier()
+        rec = recorder.attach_prediction_recorder(clf, foo="bar")
+        self.assertIsInstance(rec, recorder.PredictionRecorder)
+        self.assertIs(clf.recorder, rec)
+        self.assertEqual(rec.top_level_settings["foo"], "bar")
+
+    def test_add_prediction_records_data(self):
+        clf = DummyClassifier()
+        rec = recorder.PredictionRecorder(clf, batch_size=8)
+        rec.add_prediction(["img1.png", "img2.png"], label="cat", score=0.9)
+        self.assertEqual(len(rec.predictions), 1)
+        pred = rec.predictions[0]
+        self.assertEqual(pred["images"], ["img1.png", "img2.png"])
+        self.assertEqual(pred["details"]["label"], "cat")
+        self.assertEqual(pred["details"]["score"], 0.9)
+        self.assertIsNotNone(rec.end)
+
+    def test_save_recorded_predictions_creates_file(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            clf = DummyClassifier()
+            rec = recorder.attach_prediction_recorder(clf, foo="bar")
+            rec.add_prediction(["img1.png"], label="dog")
+            out_path = os.path.join(tmpdirname, "report.txt")
+            recorder.save_recorded_predictions(clf, out_path)
+            self.assertTrue(os.path.exists(out_path))
+            with open(out_path, "r") as f:
+                content = f.read()
+            self.assertIn("Prediction Log", content)
+            self.assertIn("dog", content)
+            self.assertIn("img1.png", content)
+
+    def test_save_recorded_predictions_raises_without_recorder(self):
+        clf = DummyClassifier()
+        clf.recorder = None
+        with self.assertRaises(ValueError):
+            recorder.save_recorded_predictions(clf, "dummy.txt")
+
+    def test_save_recorded_predictions_json_file(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            clf = DummyClassifier()
+            rec = recorder.attach_prediction_recorder(clf, foo="bar")
+            rec.add_prediction(["img1.png"], label="dog")
+            out_path = os.path.join(tmpdirname, "report.json")
+            recorder.save_recorded_predictions(clf, out_path)
+            self.assertTrue(os.path.exists(out_path))
+            with open(out_path, "r") as f:
+                data = json.load(f)
+            self.assertIn("pybioclip_version", data)
+            self.assertIn("predictions", data)
+            self.assertEqual(data["predictions"][0]["images"], ["img1.png"])
+            self.assertEqual(data["predictions"][0]["details"]["label"], "dog")
+
+    def test_prediction_log_report_format_key(self):
+        self.assertEqual(recorder.PredictionLogReport.format_key("foo_bar"), "Foo Bar")
+        self.assertEqual(recorder.PredictionLogReport.format_key("batch"), "Batch")
+
+    def test_prediction_log_report_adds_top_level_info(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            clf = DummyClassifier(model_str="clip", pretrained_str=None, device="cuda")
+            rec = recorder.PredictionRecorder(clf, alpha=0.5, beta=None)
+            rec.add_prediction(["img.png"], label="cat")
+            report = recorder.PredictionLogReport(rec, command_line="bioclip predict image.jpeg")
+            out_path = os.path.join(tmpdirname, "report2.txt")
+            report.save(out_path)
+            with open(out_path, "r") as f:
+                text = f.read()
+            self.assertIn("Model: clip", text)
+            self.assertIn("Device: cuda", text)
+            self.assertIn("Alpha: 0.5", text)
+            self.assertNotIn("Beta:", text)  # None values are skipped
+
+    def test_prediction_log_report_adds_multiple_predictions(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            clf = DummyClassifier()
+            rec = recorder.PredictionRecorder(clf)
+            rec.add_prediction(["a.png"], label="a")
+            rec.add_prediction(["b.png"], label="b")
+            report = recorder.PredictionLogReport(rec, command_line="bioclip predict image.jpeg")
+            out_path = os.path.join(tmpdirname, "report3.txt")
+            report.save(out_path)
+            with open(out_path, "r") as f:
+                text = f.read()
+            self.assertIn("a.png", text)
+            self.assertIn("b.png", text)
+            self.assertEqual(text.count("Images:"), 2)
+
+    def test_create_dictionary_contains_expected_keys(self):
+        clf = DummyClassifier(model_str="clip", pretrained_str="openai", device="cuda")
+        rec = recorder.PredictionRecorder(clf, foo="bar", batch_size=4)
+        rec.add_prediction(["img1.png"], label="cat", score=0.95)
+        report = recorder.PredictionLogReport(rec, command_line="python script.py")
+        d = report.create_dictionary()
+        self.assertIn("pybioclip_version", d)
+        self.assertIn("start", d)
+        self.assertIn("end", d)
+        self.assertIn("command_line", d)
+        self.assertIn("model", d)
+        self.assertIn("pretrained", d)
+        self.assertIn("device", d)
+        self.assertIn("top_level_settings", d)
+        self.assertIn("predictions", d)
+        self.assertEqual(d["model"], "clip")
+        self.assertEqual(d["pretrained"], "openai")
+        self.assertEqual(d["device"], "cuda")
+        self.assertEqual(d["top_level_settings"]["foo"], "bar")
+        self.assertEqual(d["top_level_settings"]["batch_size"], 4)
+        self.assertEqual(d["predictions"][0]["images"], ["img1.png"])
+        self.assertEqual(d["predictions"][0]["details"]["label"], "cat")
+        self.assertEqual(d["predictions"][0]["details"]["score"], 0.95)
+
+    def test_create_report_json_output(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            clf = DummyClassifier()
+            rec = recorder.PredictionRecorder(clf, foo="bar")
+            rec.add_prediction(["img1.png"], label="dog")
+            out_path = os.path.join(tmpdirname, "report.json")
+            rec.create_report(out_path, command_line="python test.py")
+            self.assertTrue(os.path.exists(out_path))
+            with open(out_path, "r") as f:
+                data = json.load(f)
+            self.assertIn("pybioclip_version", data)
+            self.assertIn("predictions", data)
+            self.assertEqual(data["predictions"][0]["images"], ["img1.png"])
+            self.assertEqual(data["predictions"][0]["details"]["label"], "dog")
+            self.assertEqual(data["command_line"], "python test.py")
+
+    def test_add_prediction_updates_end_time(self):
+        clf = DummyClassifier()
+        rec = recorder.PredictionRecorder(clf)
+        before = rec.start
+        rec.add_prediction(["img1.png"], label="cat")
+        self.assertIsNotNone(rec.end)
+        self.assertGreaterEqual(rec.end, before)
+
+    def test_attach_prediction_recorder_passes_top_level_settings(self):
+        clf = DummyClassifier()
+        rec = recorder.attach_prediction_recorder(clf, param1=123, param2="abc")
+        self.assertEqual(rec.top_level_settings["param1"], 123)
+        self.assertEqual(rec.top_level_settings["param2"], "abc")
+
+    def test_save_recorded_predictions_raises_when_json_exists(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            clf = DummyClassifier()
+            rec = recorder.attach_prediction_recorder(clf)
+            rec.add_prediction(["img1.png"], label="dog")
+            out_path = os.path.join(tmpdirname, "report.json")
+            with open(out_path, "w") as f:
+                json.dump({"existing": "data"}, f)
+            with self.assertRaises(ValueError):
+                recorder.save_recorded_predictions(clf, out_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds `--log <path>` argument to the predict command to record prediction details to a file.

Fixes #113