### PR TITLE
Scope workflow permissions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  pages: write
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Scope workflow permissions to avoid interruption on reseting of Organization base permissions for workflow tokens.

We may also want to consider limiting workflow runs (on tests) to only when relevant files are edited.