### PR TITLE
fix: release GPU tensors after prediction

### DIFF
--- a/src/bioclip/predict.py
+++ b/src/bioclip/predict.py
@@ -277,9 +277,9 @@ class BaseClassifier(nn.Module):
                                         txt_features: torch.Tensor) -> dict[str, torch.Tensor]:
         images = [self.ensure_rgb_image(image) for image in images]
         img_features = self.create_image_features(images)
-        probs_gpu = self.create_probabilities(img_features, txt_features)
-        probs = probs_gpu.detach().cpu()
-        del probs_gpu, img_features
+        probs = self.create_probabilities(img_features, txt_features)
+        # prevent accumulation of GPU VRAM
+        probs = probs.detach().cpu()
         result = {}
         for i, key in enumerate(keys):
             result[key] = probs[i]


### PR DESCRIPTION
# Summary
- avoid retaining per-image probability tensors on the GPU during prediction
- detach probabilities to CPU and drop intermediate GPU tensors after each batch
- prevents large runs (~7k images) from exceeding VRAM (32GB)

Fixes #145.