### PR TITLE
Adds `image_features` parameter to predict for pre-computed embeddings

### DIFF
--- a/src/bioclip/predict.py
+++ b/src/bioclip/predict.py
@@ -272,6 +272,39 @@ class BaseClassifier(nn.Module):
         logits = (self.model.logit_scale.exp() * img_features @ txt_features)
         return F.softmax(logits, dim=1)
 
+    def create_probabilities_from_features(self, image_features: torch.Tensor,
+                                           txt_features: torch.Tensor,
+                                           keys: List[str]) -> dict[str, torch.Tensor]:
+        """
+        Computes probabilities from pre-computed image features.
+
+        Args:
+            image_features (torch.Tensor): Pre-computed image embeddings (N, embedding_dim).
+                Normalized if not already (checked via L2 norm).
+            txt_features (torch.Tensor): Text embeddings.
+            keys (List[str]): Keys to label each image in the output.
+
+        Returns:
+            dict[str, torch.Tensor]: A mapping of keys to probability tensors.
+        """
+        expected_dim = self.model.visual.output_dim
+        actual_dim = image_features.shape[-1]
+        if actual_dim != expected_dim:
+            raise ValueError(
+                f"image_features embedding_dim ({actual_dim}) does not match "
+                f"model's expected dimension ({expected_dim})."
+            )
+        img_features = image_features.to(self.device)
+        norms = img_features.norm(dim=-1)
+        if not torch.allclose(norms, torch.ones_like(norms), atol=1e-6):
+            img_features = F.normalize(img_features, dim=-1)
+        probs = self.create_probabilities(img_features, txt_features)
+        probs = probs.detach().cpu()
+        result = {}
+        for i, key in enumerate(keys):
+            result[key] = probs[i]
+        return result
+
     def create_probabilities_for_images(self, images: List[str] | List[PIL.Image.Image],
                                         keys: List[str],
                                         txt_features: torch.Tensor) -> dict[str, torch.Tensor]:
@@ -392,34 +425,54 @@ class CustomLabelsClassifier(BaseClassifier):
         return all_features
 
     @torch.no_grad()
-    def predict(self, images: List[str] | str | List[PIL.Image.Image], k: int = None,
-                batch_size: int = 10, callback: Optional[Callable[[int, int], None]] = None) -> dict[str, float]:
+    def predict(self, images: List[str] | str | List[PIL.Image.Image] | None = None, k: int = None,
+                batch_size: int = 10, callback: Optional[Callable[[int, int], None]] = None,
+                image_features: torch.Tensor | None = None) -> dict[str, float]:
         """
         Predicts the probabilities for the given images.
 
         Parameters:
-            images (List[str] | str | List[PIL.Image.Image]): A list of image file paths, a single image file path, or a list of PIL Image objects.
+            images (List[str] | str | List[PIL.Image.Image] | None): A list of image file paths, a single image file path, or a list of PIL Image objects.
+                Used for generating output keys. Can be None when image_features is provided.
             k (int, optional): The number of top probabilities to return. If not specified or if greater than the number of classes, all probabilities are returned.
             batch_size (int, optional): The number of images to process in a batch.
             callback (Callable[[int, int], None], optional): A callback function that takes two integers (processed, total) to report progress.
+            image_features (torch.Tensor, optional): Pre-computed image embeddings (N, embedding_dim).
+                When provided, skips image encoding. Embeddings are normalized if not already.
 
         Returns:
             List[dict]: A list of dicts with keys "file_name" and the custom class labels.
         """
-        if isinstance(images, str):
-            images = [images]
-        probs = self.create_batched_probabilities_for_images(images, self.txt_embeddings,
-                                                             batch_size=batch_size,
-                                                             callback=callback)
+        if images is None and image_features is None:
+            raise ValueError("Either images or image_features must be provided.")
+        if image_features is not None:
+            if image_features.dim() != 2:
+                raise ValueError(f"image_features must be a 2D tensor (N, embedding_dim), got {image_features.dim()}D.")
+            n = image_features.shape[0]
+            if images is not None:
+                if isinstance(images, str):
+                    images = [images]
+                if len(images) != n:
+                    raise ValueError(f"Length of images ({len(images)}) must match image_features ({n}).")
+                keys = [self.make_key(image, i) for i, image in enumerate(images)]
+            else:
+                keys = [str(i) for i in range(n)]
+            probs = self.create_probabilities_from_features(image_features, self.txt_embeddings, keys)
+        else:
+            if isinstance(images, str):
+                images = [images]
+            probs = self.create_batched_probabilities_for_images(images, self.txt_embeddings,
+                                                                 batch_size=batch_size,
+                                                                 callback=callback)
         result = []
-        for i, image in enumerate(images):
-            key = self.make_key(image, i)
+        image_keys = list(probs.keys())
+        for key in image_keys:
             img_probs = probs[key]
             if not k or k > len(self.classes):
                 k = len(self.classes)
             result.extend(self.group_probs(key, img_probs, k))
 
-        self.record_event(images=images, k=k, batch_size=batch_size)
+        self.record_event(images=images or [], k=k, batch_size=batch_size)
         return result
 
     def group_probs(self, image_key: str, img_probs: torch.Tensor, k: int = None) -> List[dict[str, float]]:
@@ -659,38 +712,56 @@ class TreeOfLifeClassifier(BaseClassifier):
         return prediction_ary
 
     @torch.no_grad()
-    def predict(self, images: List[str] | str | List[PIL.Image.Image], rank: Rank, 
+    def predict(self, images: List[str] | str | List[PIL.Image.Image] | None = None, rank: Rank = Rank.SPECIES,
                 min_prob: float = 1e-9, k: int = 5, batch_size: int = 10,
-                callback: Optional[Callable[[int, int], None]] = None) -> dict[str, dict[str, float]]:
+                callback: Optional[Callable[[int, int], None]] = None,
+                image_features: torch.Tensor | None = None) -> dict[str, dict[str, float]]:
         """
         Predicts probabilities for supplied taxa rank for given images using the Tree of Life embeddings.
 
         Parameters:
-            images (List[str] | str | List[PIL.Image.Image]): A list of image file paths, a single image file path, or a list of PIL Image objects.
+            images (List[str] | str | List[PIL.Image.Image] | None): A list of image file paths, a single image file path, or a list of PIL Image objects.
+                Used for generating output keys. Can be None when image_features is provided.
             rank (Rank): The rank at which to make predictions (e.g., species, genus).
             min_prob (float, optional): The minimum probability threshold for predictions.
             k (int, optional): The number of top predictions to return.
             batch_size (int, optional): The number of images to process in a batch.
             callback (Callable[[int, int], None], optional): A callback function that takes two integers (processed, total) to report progress.
+            image_features (torch.Tensor, optional): Pre-computed image embeddings (N, embedding_dim).
+                When provided, skips image encoding. Embeddings are normalized if not already.
 
         Returns:
             List[dict]: A list of dicts with keys "file_name", taxon ranks, "common_name", and "score".
         """
-
-        if isinstance(images, str):
-            images = [images]
-        probs = self.create_batched_probabilities_for_images(images, self.get_txt_embeddings(),
-                                                             batch_size=batch_size,
-                                                             callback=callback)
+        if images is None and image_features is None:
+            raise ValueError("Either images or image_features must be provided.")
+        if image_features is not None:
+            if image_features.dim() != 2:
+                raise ValueError(f"image_features must be a 2D tensor (N, embedding_dim), got {image_features.dim()}D.")
+            n = image_features.shape[0]
+            if images is not None:
+                if isinstance(images, str):
+                    images = [images]
+                if len(images) != n:
+                    raise ValueError(f"Length of images ({len(images)}) must match image_features ({n}).")
+                keys = [self.make_key(image, i) for i, image in enumerate(images)]
+            else:
+                keys = [str(i) for i in range(n)]
+            probs = self.create_probabilities_from_features(image_features, self.get_txt_embeddings(), keys)
+        else:
+            if isinstance(images, str):
+                images = [images]
+            probs = self.create_batched_probabilities_for_images(images, self.get_txt_embeddings(),
+                                                                 batch_size=batch_size,
+                                                                 callback=callback)
         result = []
-        for i, image in enumerate(images):
-            key = self.make_key(image, i)
+        for key in probs.keys():
             image_probs = probs[key].cpu()
             if rank == Rank.SPECIES:
                 result.extend(self.format_species_probs(key, image_probs, k))
             else:
                 result.extend(self.format_grouped_probs(key, image_probs, rank, min_prob, k))
-        self.record_event(images=images, rank=rank.get_label(), min_prob=min_prob, k=k, batch_size=batch_size)
+        self.record_event(images=images or [], rank=rank.get_label(), min_prob=min_prob, k=k, batch_size=batch_size)
         return result
 
 

--- a/src/bioclip/predict.py
+++ b/src/bioclip/predict.py
@@ -242,6 +242,39 @@ class BaseClassifier(nn.Module):
         logits = (self.model.logit_scale.exp() * img_features @ txt_features)
         return F.softmax(logits, dim=1)
 
+    def create_probabilities_from_features(self, image_features: torch.Tensor,
+                                           txt_features: torch.Tensor,
+                                           keys: List[str]) -> dict[str, torch.Tensor]:
+        """
+        Computes probabilities from pre-computed image features.
+
+        Args:
+            image_features (torch.Tensor): Pre-computed image embeddings (N, embedding_dim).
+                Normalized if not already (checked via L2 norm).
+            txt_features (torch.Tensor): Text embeddings.
+            keys (List[str]): Keys to label each image in the output.
+
+        Returns:
+            dict[str, torch.Tensor]: A mapping of keys to probability tensors.
+        """
+        expected_dim = self.model.visual.output_dim
+        actual_dim = image_features.shape[-1]
+        if actual_dim != expected_dim:
+            raise ValueError(
+                f"image_features embedding_dim ({actual_dim}) does not match "
+                f"model's expected dimension ({expected_dim})."
+            )
+        img_features = image_features.to(self.device)
+        norms = img_features.norm(dim=-1)
+        if not torch.allclose(norms, torch.ones_like(norms), atol=1e-6):
+            img_features = F.normalize(img_features, dim=-1)
+        probs = self.create_probabilities(img_features, txt_features)
+        probs = probs.detach().cpu()
+        result = {}
+        for i, key in enumerate(keys):
+            result[key] = probs[i]
+        return result
+
     def create_probabilities_for_images(self, images: List[str] | List[PIL.Image.Image],
                                         keys: List[str],
                                         txt_features: torch.Tensor) -> dict[str, torch.Tensor]:
@@ -362,34 +395,54 @@ class CustomLabelsClassifier(BaseClassifier):
         return all_features
 
     @torch.no_grad()
-    def predict(self, images: List[str] | str | List[PIL.Image.Image], k: int = None,
-                batch_size: int = 10, callback: Optional[Callable[[int, int], None]] = None) -> dict[str, float]:
+    def predict(self, images: List[str] | str | List[PIL.Image.Image] | None = None, k: int = None,
+                batch_size: int = 10, callback: Optional[Callable[[int, int], None]] = None,
+                image_features: torch.Tensor | None = None) -> dict[str, float]:
         """
         Predicts the probabilities for the given images.
 
         Parameters:
-            images (List[str] | str | List[PIL.Image.Image]): A list of image file paths, a single image file path, or a list of PIL Image objects.
+            images (List[str] | str | List[PIL.Image.Image] | None): A list of image file paths, a single image file path, or a list of PIL Image objects.
+                Used for generating output keys. Can be None when image_features is provided.
             k (int, optional): The number of top probabilities to return. If not specified or if greater than the number of classes, all probabilities are returned.
             batch_size (int, optional): The number of images to process in a batch.
             callback (Callable[[int, int], None], optional): A callback function that takes two integers (processed, total) to report progress.
+            image_features (torch.Tensor, optional): Pre-computed image embeddings (N, embedding_dim).
+                When provided, skips image encoding. Embeddings are normalized if not already.
 
         Returns:
             List[dict]: A list of dicts with keys "file_name" and the custom class labels.
         """
-        if isinstance(images, str):
-            images = [images]
-        probs = self.create_batched_probabilities_for_images(images, self.txt_embeddings,
-                                                             batch_size=batch_size,
-                                                             callback=callback)
+        if images is None and image_features is None:
+            raise ValueError("Either images or image_features must be provided.")
+        if image_features is not None:
+            if image_features.dim() != 2:
+                raise ValueError(f"image_features must be a 2D tensor (N, embedding_dim), got {image_features.dim()}D.")
+            n = image_features.shape[0]
+            if images is not None:
+                if isinstance(images, str):
+                    images = [images]
+                if len(images) != n:
+                    raise ValueError(f"Length of images ({len(images)}) must match image_features ({n}).")
+                keys = [self.make_key(image, i) for i, image in enumerate(images)]
+            else:
+                keys = [str(i) for i in range(n)]
+            probs = self.create_probabilities_from_features(image_features, self.txt_embeddings, keys)
+        else:
+            if isinstance(images, str):
+                images = [images]
+            probs = self.create_batched_probabilities_for_images(images, self.txt_embeddings,
+                                                                 batch_size=batch_size,
+                                                                 callback=callback)
         result = []
-        for i, image in enumerate(images):
-            key = self.make_key(image, i)
+        image_keys = list(probs.keys())
+        for key in image_keys:
             img_probs = probs[key]
             if not k or k > len(self.classes):
                 k = len(self.classes)
             result.extend(self.group_probs(key, img_probs, k))
 
-        self.record_event(images=images, k=k, batch_size=batch_size)
+        self.record_event(images=images or [], k=k, batch_size=batch_size)
         return result
 
     def group_probs(self, image_key: str, img_probs: torch.Tensor, k: int = None) -> List[dict[str, float]]:
@@ -629,38 +682,56 @@ class TreeOfLifeClassifier(BaseClassifier):
         return prediction_ary
 
     @torch.no_grad()
-    def predict(self, images: List[str] | str | List[PIL.Image.Image], rank: Rank, 
+    def predict(self, images: List[str] | str | List[PIL.Image.Image] | None = None, rank: Rank = Rank.SPECIES,
                 min_prob: float = 1e-9, k: int = 5, batch_size: int = 10,
-                callback: Optional[Callable[[int, int], None]] = None) -> dict[str, dict[str, float]]:
+                callback: Optional[Callable[[int, int], None]] = None,
+                image_features: torch.Tensor | None = None) -> dict[str, dict[str, float]]:
         """
         Predicts probabilities for supplied taxa rank for given images using the Tree of Life embeddings.
 
         Parameters:
-            images (List[str] | str | List[PIL.Image.Image]): A list of image file paths, a single image file path, or a list of PIL Image objects.
+            images (List[str] | str | List[PIL.Image.Image] | None): A list of image file paths, a single image file path, or a list of PIL Image objects.
+                Used for generating output keys. Can be None when image_features is provided.
             rank (Rank): The rank at which to make predictions (e.g., species, genus).
             min_prob (float, optional): The minimum probability threshold for predictions.
             k (int, optional): The number of top predictions to return.
             batch_size (int, optional): The number of images to process in a batch.
             callback (Callable[[int, int], None], optional): A callback function that takes two integers (processed, total) to report progress.
+            image_features (torch.Tensor, optional): Pre-computed image embeddings (N, embedding_dim).
+                When provided, skips image encoding. Embeddings are normalized if not already.
 
         Returns:
             List[dict]: A list of dicts with keys "file_name", taxon ranks, "common_name", and "score".
         """
-
-        if isinstance(images, str):
-            images = [images]
-        probs = self.create_batched_probabilities_for_images(images, self.get_txt_embeddings(),
-                                                             batch_size=batch_size,
-                                                             callback=callback)
+        if images is None and image_features is None:
+            raise ValueError("Either images or image_features must be provided.")
+        if image_features is not None:
+            if image_features.dim() != 2:
+                raise ValueError(f"image_features must be a 2D tensor (N, embedding_dim), got {image_features.dim()}D.")
+            n = image_features.shape[0]
+            if images is not None:
+                if isinstance(images, str):
+                    images = [images]
+                if len(images) != n:
+                    raise ValueError(f"Length of images ({len(images)}) must match image_features ({n}).")
+                keys = [self.make_key(image, i) for i, image in enumerate(images)]
+            else:
+                keys = [str(i) for i in range(n)]
+            probs = self.create_probabilities_from_features(image_features, self.get_txt_embeddings(), keys)
+        else:
+            if isinstance(images, str):
+                images = [images]
+            probs = self.create_batched_probabilities_for_images(images, self.get_txt_embeddings(),
+                                                                 batch_size=batch_size,
+                                                                 callback=callback)
         result = []
-        for i, image in enumerate(images):
-            key = self.make_key(image, i)
+        for key in probs.keys():
             image_probs = probs[key].cpu()
             if rank == Rank.SPECIES:
                 result.extend(self.format_species_probs(key, image_probs, k))
             else:
                 result.extend(self.format_grouped_probs(key, image_probs, rank, min_prob, k))
-        self.record_event(images=images, rank=rank.get_label(), min_prob=min_prob, k=k, batch_size=batch_size)
+        self.record_event(images=images or [], rank=rank.get_label(), min_prob=min_prob, k=k, batch_size=batch_size)
         return result
 
 

--- a/src/bioclip/predict.py
+++ b/src/bioclip/predict.py
@@ -239,24 +239,32 @@ class BaseClassifier(nn.Module):
 
     def create_probabilities(self, img_features: torch.Tensor,
                              txt_features: torch.Tensor) -> dict[str, torch.Tensor]:
+        """
+        Given image features and text features,
+        return softmax probabilities of the logits for each class for each image.
+        
+        Assumes `img_features` and `txt_features` are normalized 
+        and on the same device. 
+        """
         logits = (self.model.logit_scale.exp() * img_features @ txt_features)
         return F.softmax(logits, dim=1)
 
-    def create_probabilities_from_features(self, image_features: torch.Tensor,
-                                           txt_features: torch.Tensor,
-                                           keys: List[str]) -> dict[str, torch.Tensor]:
+    def _validate_image_features(self, image_features: torch.Tensor) -> torch.Tensor:
         """
-        Computes probabilities from pre-computed image features.
+        Validates pre-computed image embeddings and returns them on self.device,
+        L2-normalized if not already unit-norm.
 
-        Args:
-            image_features (torch.Tensor): Pre-computed image embeddings (N, embedding_dim).
-                Normalized if not already (checked via L2 norm).
-            txt_features (torch.Tensor): Text embeddings.
-            keys (List[str]): Keys to label each image in the output.
-
-        Returns:
-            dict[str, torch.Tensor]: A mapping of keys to probability tensors.
+        Raises:
+            ValueError: If image_features is not 2D, or if its trailing dimension does
+                not match the model's vision tower output dimension.
         """
+        
+        # Validate dimensions
+        ## Expecting (N, embedding_dim)
+        if image_features.dim() != 2:
+            raise ValueError(
+                f"image_features must be a 2D tensor (N, embedding_dim), got {image_features.dim()}D."
+            )
         expected_dim = self.model.visual.output_dim
         actual_dim = image_features.shape[-1]
         if actual_dim != expected_dim:
@@ -264,16 +272,65 @@ class BaseClassifier(nn.Module):
                 f"image_features embedding_dim ({actual_dim}) does not match "
                 f"model's expected dimension ({expected_dim})."
             )
+            
+        # Dim check passed, move to device and validate normalization
+        ## If not unit norm, apply normalization. 
+        ## Allowing some numerical tolerance for floating point issues.
         img_features = image_features.to(self.device)
         norms = img_features.norm(dim=-1)
         if not torch.allclose(norms, torch.ones_like(norms), atol=1e-6):
             img_features = F.normalize(img_features, dim=-1)
-        probs = self.create_probabilities(img_features, txt_features)
-        probs = probs.detach().cpu()
-        result = {}
-        for i, key in enumerate(keys):
-            result[key] = probs[i]
-        return result
+        return img_features
+
+    def _resolve_image_features(self,
+                                images: List[str] | str | List[PIL.Image.Image] | None,
+                                image_features: torch.Tensor | None,
+                                txt_features: torch.Tensor,
+                                batch_size: int | None,
+                                callback: Optional[Callable[[int, int], None]]
+                                ) -> tuple[dict[str, torch.Tensor], List[str] | List[PIL.Image.Image]]:
+        """
+        Common input resolution for predict(): if image_features is provided, validates
+        it and computes probabilities directly; otherwise runs the batched encoding pipeline.
+
+        Returns a (probs_dict, images_list) tuple. images_list is the normalized list form
+        suitable for record_event (empty list when only image_features were supplied).
+        """
+        if images is None and image_features is None:
+            raise ValueError("Either images or image_features must be provided.")
+        
+        # Image features provided
+        if image_features is not None:
+            # First validate dim of provided image_features
+            image_features = self._validate_image_features(image_features)
+            n = image_features.shape[0]
+            
+            # Check if images were provided
+            # If so, validate length and create keys; 
+            # if not, create dummy keys and empty images list for record_event
+            if images is not None:
+                if isinstance(images, str):
+                    images = [images]
+                if len(images) != n:
+                    raise ValueError(
+                        f"Length of images ({len(images)}) must match image_features ({n})."
+                    )
+                keys = [self.make_key(image, i) for i, image in enumerate(images)]
+            else:
+                images = []
+                keys = [str(i) for i in range(n)]
+            
+            # With validated image_features and keys, compute probabilities
+            probs = self.create_probabilities(image_features, txt_features).detach().cpu()
+            return {key: probs[i] for i, key in enumerate(keys)}, images
+        
+        # No image features provided, must run encoding pipeline on images
+        if isinstance(images, str):
+            images = [images]
+        probs = self.create_batched_probabilities_for_images(
+            images, txt_features, batch_size=batch_size, callback=callback,
+        )
+        return probs, images
 
     def create_probabilities_for_images(self, images: List[str] | List[PIL.Image.Image],
                                         keys: List[str],
@@ -403,46 +460,30 @@ class CustomLabelsClassifier(BaseClassifier):
 
         Parameters:
             images (List[str] | str | List[PIL.Image.Image] | None): A list of image file paths, a single image file path, or a list of PIL Image objects.
-                Used for generating output keys. Can be None when image_features is provided.
+                Used for generating output keys. May be None when image_features is provided. When both images and image_features are provided, their lengths must match.
             k (int, optional): The number of top probabilities to return. If not specified or if greater than the number of classes, all probabilities are returned.
             batch_size (int, optional): The number of images to process in a batch.
             callback (Callable[[int, int], None], optional): A callback function that takes two integers (processed, total) to report progress.
-            image_features (torch.Tensor, optional): Pre-computed image embeddings (N, embedding_dim).
-                When provided, skips image encoding. Embeddings are normalized if not already.
+            image_features (torch.Tensor, optional): Pre-computed image embeddings of shape (N, embedding_dim).
+                When provided, skips image encoding. Normalized internally if not already unit-norm.
+                When supplied without images, output "file_name" entries are the zero-based index as a string ("0", "1", ...).
 
         Returns:
             List[dict]: A list of dicts with keys "file_name" and the custom class labels.
+
+        Raises:
+            ValueError: If neither images nor image_features is provided, if image_features
+                has the wrong shape, or if images and image_features lengths disagree.
         """
-        if images is None and image_features is None:
-            raise ValueError("Either images or image_features must be provided.")
-        if image_features is not None:
-            if image_features.dim() != 2:
-                raise ValueError(f"image_features must be a 2D tensor (N, embedding_dim), got {image_features.dim()}D.")
-            n = image_features.shape[0]
-            if images is not None:
-                if isinstance(images, str):
-                    images = [images]
-                if len(images) != n:
-                    raise ValueError(f"Length of images ({len(images)}) must match image_features ({n}).")
-                keys = [self.make_key(image, i) for i, image in enumerate(images)]
-            else:
-                keys = [str(i) for i in range(n)]
-            probs = self.create_probabilities_from_features(image_features, self.txt_embeddings, keys)
-        else:
-            if isinstance(images, str):
-                images = [images]
-            probs = self.create_batched_probabilities_for_images(images, self.txt_embeddings,
-                                                                 batch_size=batch_size,
-                                                                 callback=callback)
+        probs, images = self._resolve_image_features(
+            images, image_features, self.txt_embeddings, batch_size, callback,
+        )
         result = []
-        image_keys = list(probs.keys())
-        for key in image_keys:
-            img_probs = probs[key]
+        for key, img_probs in probs.items():
             if not k or k > len(self.classes):
                 k = len(self.classes)
             result.extend(self.group_probs(key, img_probs, k))
-
-        self.record_event(images=images or [], k=k, batch_size=batch_size)
+        self.record_event(images=images, k=k, batch_size=batch_size)
         return result
 
     def group_probs(self, image_key: str, img_probs: torch.Tensor, k: int = None) -> List[dict[str, float]]:
@@ -682,7 +723,7 @@ class TreeOfLifeClassifier(BaseClassifier):
         return prediction_ary
 
     @torch.no_grad()
-    def predict(self, images: List[str] | str | List[PIL.Image.Image] | None = None, rank: Rank = Rank.SPECIES,
+    def predict(self, images: List[str] | str | List[PIL.Image.Image] | None = None, rank: Rank | None = None,
                 min_prob: float = 1e-9, k: int = 5, batch_size: int = 10,
                 callback: Optional[Callable[[int, int], None]] = None,
                 image_features: torch.Tensor | None = None) -> dict[str, dict[str, float]]:
@@ -691,47 +732,37 @@ class TreeOfLifeClassifier(BaseClassifier):
 
         Parameters:
             images (List[str] | str | List[PIL.Image.Image] | None): A list of image file paths, a single image file path, or a list of PIL Image objects.
-                Used for generating output keys. Can be None when image_features is provided.
-            rank (Rank): The rank at which to make predictions (e.g., species, genus).
+                Used for generating output keys. May be None when image_features is provided. When both images and image_features are provided, their lengths must match.
+            rank (Rank): Required. The rank at which to make predictions (e.g., species, genus).
             min_prob (float, optional): The minimum probability threshold for predictions.
             k (int, optional): The number of top predictions to return.
             batch_size (int, optional): The number of images to process in a batch.
             callback (Callable[[int, int], None], optional): A callback function that takes two integers (processed, total) to report progress.
-            image_features (torch.Tensor, optional): Pre-computed image embeddings (N, embedding_dim).
-                When provided, skips image encoding. Embeddings are normalized if not already.
+            image_features (torch.Tensor, optional): Pre-computed image embeddings of shape (N, embedding_dim).
+                When provided, skips image encoding. Normalized internally if not already unit-norm.
+                When supplied without images, output "file_name" entries are the zero-based index as a string ("0", "1", ...).
 
         Returns:
             List[dict]: A list of dicts with keys "file_name", taxon ranks, "common_name", and "score".
+
+        Raises:
+            TypeError: If rank is not provided.
+            ValueError: If neither images nor image_features is provided, if image_features
+                has the wrong shape, or if images and image_features lengths disagree.
         """
-        if images is None and image_features is None:
-            raise ValueError("Either images or image_features must be provided.")
-        if image_features is not None:
-            if image_features.dim() != 2:
-                raise ValueError(f"image_features must be a 2D tensor (N, embedding_dim), got {image_features.dim()}D.")
-            n = image_features.shape[0]
-            if images is not None:
-                if isinstance(images, str):
-                    images = [images]
-                if len(images) != n:
-                    raise ValueError(f"Length of images ({len(images)}) must match image_features ({n}).")
-                keys = [self.make_key(image, i) for i, image in enumerate(images)]
-            else:
-                keys = [str(i) for i in range(n)]
-            probs = self.create_probabilities_from_features(image_features, self.get_txt_embeddings(), keys)
-        else:
-            if isinstance(images, str):
-                images = [images]
-            probs = self.create_batched_probabilities_for_images(images, self.get_txt_embeddings(),
-                                                                 batch_size=batch_size,
-                                                                 callback=callback)
+        if rank is None:
+            raise TypeError("predict() missing 1 required argument: 'rank'")
+        probs, images = self._resolve_image_features(
+            images, image_features, self.get_txt_embeddings(), batch_size, callback,
+        )
         result = []
-        for key in probs.keys():
-            image_probs = probs[key].cpu()
+        for key, image_probs in probs.items():
+            image_probs = image_probs.cpu()
             if rank == Rank.SPECIES:
                 result.extend(self.format_species_probs(key, image_probs, k))
             else:
                 result.extend(self.format_grouped_probs(key, image_probs, rank, min_prob, k))
-        self.record_event(images=images or [], rank=rank.get_label(), min_prob=min_prob, k=k, batch_size=batch_size)
+        self.record_event(images=images, rank=rank.get_label(), min_prob=min_prob, k=k, batch_size=batch_size)
         return result
 
 

--- a/src/bioclip/predict.py
+++ b/src/bioclip/predict.py
@@ -293,34 +293,32 @@ class BaseClassifier(nn.Module):
         Common input resolution for predict(): if image_features is provided, validates
         it and computes probabilities directly; otherwise runs the batched encoding pipeline.
 
-        Returns a (probs_dict, images_list) tuple. images_list is the normalized list form
-        suitable for record_event (empty list when only image_features were supplied).
+        images is required in both paths. When image_features is provided, images supplies
+        the identifiers used to construct output keys; image_features supplies the
+        embeddings used for inference (skipping the encoder). Their lengths must match.
+
+        Returns a (probs_dict, images_list) tuple where images_list is the normalized list
+        form (string-to-list converted).
         """
         if images is None and image_features is None:
             raise ValueError("Either images or image_features must be provided.")
-        
-        # Image features provided
+
+        # Image features provided: images is required as identifiers for output keys.
         if image_features is not None:
-            # First validate dim of provided image_features
+            if images is None:
+                raise ValueError(
+                    "images is required when image_features is provided; pass a list of "
+                    "identifiers (e.g. filename strings) corresponding to each embedding."
+                )
             image_features = self._validate_image_features(image_features)
             n = image_features.shape[0]
-            
-            # Check if images were provided
-            # If so, validate length and create keys; 
-            # if not, create dummy keys and empty images list for record_event
-            if images is not None:
-                if isinstance(images, str):
-                    images = [images]
-                if len(images) != n:
-                    raise ValueError(
-                        f"Length of images ({len(images)}) must match image_features ({n})."
-                    )
-                keys = [self.make_key(image, i) for i, image in enumerate(images)]
-            else:
-                images = []
-                keys = [str(i) for i in range(n)]
-            
-            # With validated image_features and keys, compute probabilities
+            if isinstance(images, str):
+                images = [images]
+            if len(images) != n:
+                raise ValueError(
+                    f"Length of images ({len(images)}) must match image_features ({n})."
+                )
+            keys = [self.make_key(image, i) for i, image in enumerate(images)]
             probs = self.create_probabilities(image_features, txt_features).detach().cpu()
             return {key: probs[i] for i, key in enumerate(keys)}, images
         
@@ -459,21 +457,41 @@ class CustomLabelsClassifier(BaseClassifier):
         Predicts the probabilities for the given images.
 
         Parameters:
-            images (List[str] | str | List[PIL.Image.Image] | None): A list of image file paths, a single image file path, or a list of PIL Image objects.
-                Used for generating output keys. May be None when image_features is provided. When both images and image_features are provided, their lengths must match.
-            k (int, optional): The number of top probabilities to return. If not specified or if greater than the number of classes, all probabilities are returned.
-            batch_size (int, optional): The number of images to process in a batch.
-            callback (Callable[[int, int], None], optional): A callback function that takes two integers (processed, total) to report progress.
-            image_features (torch.Tensor, optional): Pre-computed image embeddings of shape (N, embedding_dim).
-                When provided, skips image encoding. Normalized internally if not already unit-norm.
-                When supplied without images, output "file_name" entries are the zero-based index as a string ("0", "1", ...).
+            images (List[str] | str | List[PIL.Image.Image] | None):
+                A list of image file paths, a single image file path, or a list of
+                PIL Image objects. Used for generating output keys.
+
+                Required when `image_features` is provided; its length must match
+                `image_features`.
+
+            k (int, optional):
+                The number of top probabilities to return. If not specified, or if
+                greater than the number of classes, all probabilities are returned.
+
+            batch_size (int, optional):
+                The number of images to process in a batch.
+
+            callback (Callable[[int, int], None], optional):
+                A callback function taking `(processed, total)` to report progress.
+
+            image_features (torch.Tensor, optional):
+                Pre-computed image embeddings of shape `(N, embedding_dim)`.
+                When provided, the image encoder is skipped and the embeddings are
+                used directly for inference. Embeddings are L2-normalized internally
+                if not already unit-norm. `images` is still required as identifiers
+                for the output keys.
 
         Returns:
-            List[dict]: A list of dicts with keys "file_name" and the custom class labels.
+            List[dict]: A list of dicts with keys `"file_name"` and the custom
+                class labels.
 
         Raises:
-            ValueError: If neither images nor image_features is provided, if image_features
-                has the wrong shape, or if images and image_features lengths disagree.
+            ValueError: If any of the following:
+
+                - neither `images` nor `image_features` is provided,
+                - `image_features` is provided without `images`,
+                - `image_features` is not 2D or has the wrong embedding dimension,
+                - `images` and `image_features` lengths disagree.
         """
         probs, images = self._resolve_image_features(
             images, image_features, self.txt_embeddings, batch_size, callback,
@@ -728,27 +746,51 @@ class TreeOfLifeClassifier(BaseClassifier):
                 callback: Optional[Callable[[int, int], None]] = None,
                 image_features: torch.Tensor | None = None) -> dict[str, dict[str, float]]:
         """
-        Predicts probabilities for supplied taxa rank for given images using the Tree of Life embeddings.
+        Predicts probabilities for the supplied taxonomic rank using the Tree of Life
+        embeddings.
 
         Parameters:
-            images (List[str] | str | List[PIL.Image.Image] | None): A list of image file paths, a single image file path, or a list of PIL Image objects.
-                Used for generating output keys. May be None when image_features is provided. When both images and image_features are provided, their lengths must match.
-            rank (Rank): Required. The rank at which to make predictions (e.g., species, genus).
-            min_prob (float, optional): The minimum probability threshold for predictions.
-            k (int, optional): The number of top predictions to return.
-            batch_size (int, optional): The number of images to process in a batch.
-            callback (Callable[[int, int], None], optional): A callback function that takes two integers (processed, total) to report progress.
-            image_features (torch.Tensor, optional): Pre-computed image embeddings of shape (N, embedding_dim).
-                When provided, skips image encoding. Normalized internally if not already unit-norm.
-                When supplied without images, output "file_name" entries are the zero-based index as a string ("0", "1", ...).
+            images (List[str] | str | List[PIL.Image.Image] | None):
+                A list of image file paths, a single image file path, or a list of
+                PIL Image objects. Used for generating output keys.
+
+                Required when `image_features` is provided; its length must match
+                `image_features`.
+
+            rank (Rank):
+                Required. The rank at which to make predictions (e.g. species, genus).
+
+            min_prob (float, optional):
+                The minimum probability threshold for predictions.
+
+            k (int, optional):
+                The number of top predictions to return.
+
+            batch_size (int, optional):
+                The number of images to process in a batch.
+
+            callback (Callable[[int, int], None], optional):
+                A callback function taking `(processed, total)` to report progress.
+
+            image_features (torch.Tensor, optional):
+                Pre-computed image embeddings of shape `(N, embedding_dim)`.
+                When provided, the image encoder is skipped and the embeddings are
+                used directly for inference. Embeddings are L2-normalized internally
+                if not already unit-norm. `images` is still required as identifiers
+                for the output keys.
 
         Returns:
-            List[dict]: A list of dicts with keys "file_name", taxon ranks, "common_name", and "score".
+            List[dict]: A list of dicts with keys `"file_name"`, the taxon ranks,
+                `"common_name"`, and `"score"`.
 
         Raises:
-            TypeError: If rank is not provided.
-            ValueError: If neither images nor image_features is provided, if image_features
-                has the wrong shape, or if images and image_features lengths disagree.
+            TypeError: If `rank` is not provided.
+            ValueError: If any of the following:
+
+                - neither `images` nor `image_features` is provided,
+                - `image_features` is provided without `images`,
+                - `image_features` is not 2D or has the wrong embedding dimension,
+                - `images` and `image_features` lengths disagree.
         """
         if rank is None:
             raise TypeError("predict() missing 1 required argument: 'rank'")

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -416,3 +416,144 @@ class TestEnsureTolSupportedModel(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             get_tol_repo_id("hf-hub:some/unsupported-model")
         self.assertIn("TreeOfLife predictions are only supported for the following models", str(cm.exception))
+
+
+class TestPredictFromEmbeddings(unittest.TestCase):
+    """Tests for predict() with pre-computed image_features."""
+
+    @staticmethod
+    def _assert_results_equal_ignoring_file_name(test_case, expected, actual):
+        """Assert two result lists are identical except for file_name."""
+        test_case.assertEqual(len(expected), len(actual))
+        for exp, act in zip(expected, actual):
+            for key in exp:
+                if key == 'file_name':
+                    continue
+                test_case.assertEqual(exp[key], act[key],
+                    f"Mismatch on key '{key}': {exp[key]} != {act[key]}")
+
+    def test_tol_predict_species_from_features_matches_images(self):
+        """Species-level predict from embeddings must match predict from images exactly."""
+        classifier = TreeOfLifeClassifier()
+        features = classifier.create_image_features(
+            [classifier.ensure_rgb_image(EXAMPLE_CAT_IMAGE)]
+        )
+        result_from_images = classifier.predict(images=EXAMPLE_CAT_IMAGE, rank=Rank.SPECIES, k=5)
+        result_from_features = classifier.predict(image_features=features, rank=Rank.SPECIES, k=5)
+        self._assert_results_equal_ignoring_file_name(self, result_from_images, result_from_features)
+        # file_name should be numeric index when no images provided
+        for entry in result_from_features:
+            self.assertEqual(entry['file_name'], '0')
+
+    def test_tol_predict_family_from_features_matches_images(self):
+        """Family-level predict from embeddings must match predict from images exactly."""
+        classifier = TreeOfLifeClassifier()
+        features = classifier.create_image_features(
+            [classifier.ensure_rgb_image(EXAMPLE_CAT_IMAGE)]
+        )
+        result_from_images = classifier.predict(images=EXAMPLE_CAT_IMAGE, rank=Rank.FAMILY, k=2)
+        result_from_features = classifier.predict(image_features=features, rank=Rank.FAMILY, k=2)
+        self._assert_results_equal_ignoring_file_name(self, result_from_images, result_from_features)
+
+    def test_tol_predict_multiple_from_features_matches_images(self):
+        """Multi-image predict from embeddings must match predict from images exactly."""
+        classifier = TreeOfLifeClassifier()
+        img1 = classifier.ensure_rgb_image(EXAMPLE_CAT_IMAGE)
+        img2 = classifier.ensure_rgb_image(EXAMPLE_CAT_IMAGE2)
+        features = classifier.create_image_features([img1, img2])
+        result_from_images = classifier.predict(
+            images=[EXAMPLE_CAT_IMAGE, EXAMPLE_CAT_IMAGE2], rank=Rank.SPECIES, k=5
+        )
+        result_from_features = classifier.predict(image_features=features, rank=Rank.SPECIES, k=5)
+        self._assert_results_equal_ignoring_file_name(self, result_from_images, result_from_features)
+        # Verify numeric keys for each image's results
+        for i in range(5):
+            self.assertEqual(result_from_features[i]['file_name'], '0')
+        for i in range(5, 10):
+            self.assertEqual(result_from_features[i]['file_name'], '1')
+
+    def test_tol_predict_unnormalized_features_matches_images(self):
+        """Unnormalized features should be auto-normalized and produce correct results."""
+        classifier = TreeOfLifeClassifier()
+        # Get unnormalized features
+        unnorm_features = classifier.create_image_features(
+            [classifier.ensure_rgb_image(EXAMPLE_CAT_IMAGE)], normalize=False
+        )
+        # Verify they are indeed not normalized
+        norms = unnorm_features.norm(dim=-1)
+        self.assertFalse(torch.allclose(norms, torch.ones_like(norms), atol=1e-6))
+        # Predict from unnormalized features
+        result_from_images = classifier.predict(images=EXAMPLE_CAT_IMAGE, rank=Rank.SPECIES, k=5)
+        result_from_features = classifier.predict(image_features=unnorm_features, rank=Rank.SPECIES, k=5)
+        # Classifications should match; scores may have minor float drift from normalization
+        self.assertEqual(len(result_from_images), len(result_from_features))
+        for img_res, feat_res in zip(result_from_images, result_from_features):
+            for key in img_res:
+                if key in ('file_name', 'score'):
+                    continue
+                self.assertEqual(img_res[key], feat_res[key],
+                    f"Mismatch on key '{key}': {img_res[key]} != {feat_res[key]}")
+
+    def test_custom_predict_from_features_matches_images(self):
+        """CustomLabelsClassifier predict from embeddings must match predict from images exactly."""
+        classifier = CustomLabelsClassifier(cls_ary=['cat', 'dog'])
+        features = classifier.create_image_features(
+            [classifier.ensure_rgb_image(EXAMPLE_CAT_IMAGE)]
+        )
+        result_from_images = classifier.predict(images=EXAMPLE_CAT_IMAGE)
+        result_from_features = classifier.predict(image_features=features)
+        self._assert_results_equal_ignoring_file_name(self, result_from_images, result_from_features)
+        for entry in result_from_features:
+            self.assertEqual(entry['file_name'], '0')
+
+    def test_binning_predict_from_features_matches_images(self):
+        """CustomLabelsBinningClassifier predict from embeddings must match predict from images."""
+        classifier = CustomLabelsBinningClassifier(cls_to_bin={
+            'cat': 'one',
+            'mouse': 'two',
+            'fish': 'two',
+        })
+        features = classifier.create_image_features(
+            [classifier.ensure_rgb_image(EXAMPLE_CAT_IMAGE)]
+        )
+        result_from_images = classifier.predict(images=EXAMPLE_CAT_IMAGE)
+        result_from_features = classifier.predict(image_features=features)
+        self._assert_results_equal_ignoring_file_name(self, result_from_images, result_from_features)
+
+    def test_predict_no_images_no_features_raises(self):
+        """Should raise ValueError when neither images nor image_features provided."""
+        classifier = TreeOfLifeClassifier()
+        with self.assertRaises(ValueError) as cm:
+            classifier.predict(rank=Rank.SPECIES)
+        self.assertIn("Either images or image_features must be provided", str(cm.exception))
+
+        cls_classifier = CustomLabelsClassifier(cls_ary=['cat', 'dog'])
+        with self.assertRaises(ValueError) as cm:
+            cls_classifier.predict()
+        self.assertIn("Either images or image_features must be provided", str(cm.exception))
+
+    def test_predict_image_features_wrong_dim_raises(self):
+        """Should raise ValueError for non-2D image_features tensor."""
+        classifier = TreeOfLifeClassifier()
+        with self.assertRaises(ValueError) as cm:
+            classifier.predict(image_features=torch.randn(768), rank=Rank.SPECIES)
+        self.assertIn("2D tensor", str(cm.exception))
+
+    def test_predict_image_features_wrong_embedding_dim_raises(self):
+        """Should raise ValueError when embedding_dim doesn't match model's expected dimension."""
+        classifier = TreeOfLifeClassifier()
+        # Model expects 768 for ViT-L/14, pass 512
+        features = torch.randn(1, 512)
+        with self.assertRaises(ValueError) as cm:
+            classifier.predict(image_features=features, rank=Rank.SPECIES)
+        self.assertIn("does not match", str(cm.exception))
+
+    def test_predict_image_features_length_mismatch_raises(self):
+        """Should raise ValueError when images and image_features lengths don't match."""
+        classifier = TreeOfLifeClassifier()
+        features = torch.randn(2, 768)
+        with self.assertRaises(ValueError) as cm:
+            classifier.predict(
+                images=[EXAMPLE_CAT_IMAGE], rank=Rank.SPECIES, image_features=features
+            )
+        self.assertIn("must match", str(cm.exception))

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -557,3 +557,42 @@ class TestPredictFromEmbeddings(unittest.TestCase):
                 images=[EXAMPLE_CAT_IMAGE], rank=Rank.SPECIES, image_features=features
             )
         self.assertIn("must match", str(cm.exception))
+
+    def test_custom_predict_image_features_length_mismatch_raises(self):
+        """CustomLabelsClassifier should also reject mismatched images/image_features lengths."""
+        classifier = CustomLabelsClassifier(cls_ary=['cat', 'dog'])
+        features = torch.randn(2, classifier.model.visual.output_dim)
+        with self.assertRaises(ValueError) as cm:
+            classifier.predict(images=[EXAMPLE_CAT_IMAGE], image_features=features)
+        self.assertIn("must match", str(cm.exception))
+
+    def test_tol_predict_with_both_images_and_features_uses_real_filename(self):
+        """When both images and image_features are provided, file_name must use the real image keys
+        (not the numeric "0", "1" fallback used when only image_features is supplied)."""
+        classifier = TreeOfLifeClassifier()
+        features = classifier.create_image_features(
+            [classifier.ensure_rgb_image(EXAMPLE_CAT_IMAGE)]
+        )
+        result_from_images = classifier.predict(images=EXAMPLE_CAT_IMAGE, rank=Rank.SPECIES, k=5)
+        result_from_both = classifier.predict(
+            images=EXAMPLE_CAT_IMAGE, image_features=features, rank=Rank.SPECIES, k=5,
+        )
+        # file_name must be the actual path, not a numeric index
+        for entry in result_from_both:
+            self.assertEqual(entry['file_name'], EXAMPLE_CAT_IMAGE)
+        # And the rest of the result must match the images-only path
+        self._assert_results_equal_ignoring_file_name(self, result_from_images, result_from_both)
+
+    def test_predict_rank_omitted_raises(self):
+        """TreeOfLifeClassifier.predict() must raise TypeError when rank is omitted."""
+        classifier = TreeOfLifeClassifier()
+        with self.assertRaises(TypeError) as cm:
+            classifier.predict(images=EXAMPLE_CAT_IMAGE)
+        self.assertIn("rank", str(cm.exception))
+
+        features = classifier.create_image_features(
+            [classifier.ensure_rgb_image(EXAMPLE_CAT_IMAGE)]
+        )
+        with self.assertRaises(TypeError) as cm:
+            classifier.predict(image_features=features)
+        self.assertIn("rank", str(cm.exception))

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -439,11 +439,12 @@ class TestPredictFromEmbeddings(unittest.TestCase):
             [classifier.ensure_rgb_image(EXAMPLE_CAT_IMAGE)]
         )
         result_from_images = classifier.predict(images=EXAMPLE_CAT_IMAGE, rank=Rank.SPECIES, k=5)
-        result_from_features = classifier.predict(image_features=features, rank=Rank.SPECIES, k=5)
+        result_from_features = classifier.predict(
+            images=EXAMPLE_CAT_IMAGE, image_features=features, rank=Rank.SPECIES, k=5,
+        )
         self._assert_results_equal_ignoring_file_name(self, result_from_images, result_from_features)
-        # file_name should be numeric index when no images provided
         for entry in result_from_features:
-            self.assertEqual(entry['file_name'], '0')
+            self.assertEqual(entry['file_name'], EXAMPLE_CAT_IMAGE)
 
     def test_tol_predict_family_from_features_matches_images(self):
         """Family-level predict from embeddings must match predict from images exactly."""
@@ -452,7 +453,9 @@ class TestPredictFromEmbeddings(unittest.TestCase):
             [classifier.ensure_rgb_image(EXAMPLE_CAT_IMAGE)]
         )
         result_from_images = classifier.predict(images=EXAMPLE_CAT_IMAGE, rank=Rank.FAMILY, k=2)
-        result_from_features = classifier.predict(image_features=features, rank=Rank.FAMILY, k=2)
+        result_from_features = classifier.predict(
+            images=EXAMPLE_CAT_IMAGE, image_features=features, rank=Rank.FAMILY, k=2,
+        )
         self._assert_results_equal_ignoring_file_name(self, result_from_images, result_from_features)
 
     def test_tol_predict_multiple_from_features_matches_images(self):
@@ -461,35 +464,34 @@ class TestPredictFromEmbeddings(unittest.TestCase):
         img1 = classifier.ensure_rgb_image(EXAMPLE_CAT_IMAGE)
         img2 = classifier.ensure_rgb_image(EXAMPLE_CAT_IMAGE2)
         features = classifier.create_image_features([img1, img2])
-        result_from_images = classifier.predict(
-            images=[EXAMPLE_CAT_IMAGE, EXAMPLE_CAT_IMAGE2], rank=Rank.SPECIES, k=5
+        images_list = [EXAMPLE_CAT_IMAGE, EXAMPLE_CAT_IMAGE2]
+        result_from_images = classifier.predict(images=images_list, rank=Rank.SPECIES, k=5)
+        result_from_features = classifier.predict(
+            images=images_list, image_features=features, rank=Rank.SPECIES, k=5,
         )
-        result_from_features = classifier.predict(image_features=features, rank=Rank.SPECIES, k=5)
         self._assert_results_equal_ignoring_file_name(self, result_from_images, result_from_features)
-        # Verify numeric keys for each image's results
         for i in range(5):
-            self.assertEqual(result_from_features[i]['file_name'], '0')
+            self.assertEqual(result_from_features[i]['file_name'], EXAMPLE_CAT_IMAGE)
         for i in range(5, 10):
-            self.assertEqual(result_from_features[i]['file_name'], '1')
+            self.assertEqual(result_from_features[i]['file_name'], EXAMPLE_CAT_IMAGE2)
 
     def test_tol_predict_unnormalized_features_matches_images(self):
         """Unnormalized features should be auto-normalized and produce correct results."""
         classifier = TreeOfLifeClassifier()
-        # Get unnormalized features
         unnorm_features = classifier.create_image_features(
             [classifier.ensure_rgb_image(EXAMPLE_CAT_IMAGE)], normalize=False
         )
-        # Verify they are indeed not normalized
         norms = unnorm_features.norm(dim=-1)
         self.assertFalse(torch.allclose(norms, torch.ones_like(norms), atol=1e-6))
-        # Predict from unnormalized features
         result_from_images = classifier.predict(images=EXAMPLE_CAT_IMAGE, rank=Rank.SPECIES, k=5)
-        result_from_features = classifier.predict(image_features=unnorm_features, rank=Rank.SPECIES, k=5)
+        result_from_features = classifier.predict(
+            images=EXAMPLE_CAT_IMAGE, image_features=unnorm_features, rank=Rank.SPECIES, k=5,
+        )
         # Classifications should match; scores may have minor float drift from normalization
         self.assertEqual(len(result_from_images), len(result_from_features))
         for img_res, feat_res in zip(result_from_images, result_from_features):
             for key in img_res:
-                if key in ('file_name', 'score'):
+                if key == 'score':
                     continue
                 self.assertEqual(img_res[key], feat_res[key],
                     f"Mismatch on key '{key}': {img_res[key]} != {feat_res[key]}")
@@ -501,10 +503,10 @@ class TestPredictFromEmbeddings(unittest.TestCase):
             [classifier.ensure_rgb_image(EXAMPLE_CAT_IMAGE)]
         )
         result_from_images = classifier.predict(images=EXAMPLE_CAT_IMAGE)
-        result_from_features = classifier.predict(image_features=features)
+        result_from_features = classifier.predict(images=EXAMPLE_CAT_IMAGE, image_features=features)
         self._assert_results_equal_ignoring_file_name(self, result_from_images, result_from_features)
         for entry in result_from_features:
-            self.assertEqual(entry['file_name'], '0')
+            self.assertEqual(entry['file_name'], EXAMPLE_CAT_IMAGE)
 
     def test_binning_predict_from_features_matches_images(self):
         """CustomLabelsBinningClassifier predict from embeddings must match predict from images."""
@@ -517,7 +519,7 @@ class TestPredictFromEmbeddings(unittest.TestCase):
             [classifier.ensure_rgb_image(EXAMPLE_CAT_IMAGE)]
         )
         result_from_images = classifier.predict(images=EXAMPLE_CAT_IMAGE)
-        result_from_features = classifier.predict(image_features=features)
+        result_from_features = classifier.predict(images=EXAMPLE_CAT_IMAGE, image_features=features)
         self._assert_results_equal_ignoring_file_name(self, result_from_images, result_from_features)
 
     def test_predict_no_images_no_features_raises(self):
@@ -536,7 +538,9 @@ class TestPredictFromEmbeddings(unittest.TestCase):
         """Should raise ValueError for non-2D image_features tensor."""
         classifier = TreeOfLifeClassifier()
         with self.assertRaises(ValueError) as cm:
-            classifier.predict(image_features=torch.randn(768), rank=Rank.SPECIES)
+            classifier.predict(
+                images=EXAMPLE_CAT_IMAGE, image_features=torch.randn(768), rank=Rank.SPECIES,
+            )
         self.assertIn("2D tensor", str(cm.exception))
 
     def test_predict_image_features_wrong_embedding_dim_raises(self):
@@ -545,7 +549,9 @@ class TestPredictFromEmbeddings(unittest.TestCase):
         # Model expects 768 for ViT-L/14, pass 512
         features = torch.randn(1, 512)
         with self.assertRaises(ValueError) as cm:
-            classifier.predict(image_features=features, rank=Rank.SPECIES)
+            classifier.predict(
+                images=EXAMPLE_CAT_IMAGE, image_features=features, rank=Rank.SPECIES,
+            )
         self.assertIn("does not match", str(cm.exception))
 
     def test_predict_image_features_length_mismatch_raises(self):
@@ -566,22 +572,25 @@ class TestPredictFromEmbeddings(unittest.TestCase):
             classifier.predict(images=[EXAMPLE_CAT_IMAGE], image_features=features)
         self.assertIn("must match", str(cm.exception))
 
-    def test_tol_predict_with_both_images_and_features_uses_real_filename(self):
-        """When both images and image_features are provided, file_name must use the real image keys
-        (not the numeric "0", "1" fallback used when only image_features is supplied)."""
+    def test_tol_predict_image_features_without_images_raises(self):
+        """image_features now requires images as identifiers; calling without images must raise."""
         classifier = TreeOfLifeClassifier()
         features = classifier.create_image_features(
             [classifier.ensure_rgb_image(EXAMPLE_CAT_IMAGE)]
         )
-        result_from_images = classifier.predict(images=EXAMPLE_CAT_IMAGE, rank=Rank.SPECIES, k=5)
-        result_from_both = classifier.predict(
-            images=EXAMPLE_CAT_IMAGE, image_features=features, rank=Rank.SPECIES, k=5,
+        with self.assertRaises(ValueError) as cm:
+            classifier.predict(image_features=features, rank=Rank.SPECIES)
+        self.assertIn("images is required", str(cm.exception))
+
+    def test_custom_predict_image_features_without_images_raises(self):
+        """Same images-required contract on CustomLabelsClassifier."""
+        classifier = CustomLabelsClassifier(cls_ary=['cat', 'dog'])
+        features = classifier.create_image_features(
+            [classifier.ensure_rgb_image(EXAMPLE_CAT_IMAGE)]
         )
-        # file_name must be the actual path, not a numeric index
-        for entry in result_from_both:
-            self.assertEqual(entry['file_name'], EXAMPLE_CAT_IMAGE)
-        # And the rest of the result must match the images-only path
-        self._assert_results_equal_ignoring_file_name(self, result_from_images, result_from_both)
+        with self.assertRaises(ValueError) as cm:
+            classifier.predict(image_features=features)
+        self.assertIn("images is required", str(cm.exception))
 
     def test_predict_rank_omitted_raises(self):
         """TreeOfLifeClassifier.predict() must raise TypeError when rank is omitted."""
@@ -594,5 +603,5 @@ class TestPredictFromEmbeddings(unittest.TestCase):
             [classifier.ensure_rgb_image(EXAMPLE_CAT_IMAGE)]
         )
         with self.assertRaises(TypeError) as cm:
-            classifier.predict(image_features=features)
+            classifier.predict(images=EXAMPLE_CAT_IMAGE, image_features=features)
         self.assertIn("rank", str(cm.exception))


### PR DESCRIPTION
**Disclaimer:** This PR was developed with assistance from `Claude Opus 4.6 (1M context)`. The author has reviewed all code changes and test additions. CI has been executed successfully in the [forked repo](https://github.com/NetZissou/pybioclip/actions). Opening this PR to request review from the package maintainers for further feedback and iteration.

## Summary

This PR adds an optional `image_features` parameter to `predict()` on `TreeOfLifeClassifier` and `CustomLabelsClassifier` (`CustomLabelsBinningClassifier` inherits this through `CustomLabelsClassifier`). When provided, the method skips image encoding and computes classification directly from pre-computed embeddings.

## Embedding validation

The method validates input embeddings before classification:
- Verifies tensor is 2D `(N, embedding_dim)`
- Checks that `embedding_dim` matches the model's expected dimension (`model.visual.output_dim`)
- Normalizes the embedding vector via L2 norm only if not already normalized

## Test plan

New tests in `TestPredictFromEmbeddings`:
- Results from embeddings match results from images exactly (all fields except `file_name`)
- Species, family, and multi-image predictions
- Unnormalized features auto-normalized with correct classifications
- `CustomLabelsClassifier` and `CustomLabelsBinningClassifier`
- Error cases: no inputs, wrong tensor dim, wrong embedding dim, image-embedding length mismatch

Closes #167
