### PR TITLE
Add more TreeOfLife Models

### DIFF
--- a/src/bioclip/__init__.py
+++ b/src/bioclip/__init__.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2024-present John Bradley <johnbradley2008@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-from bioclip.predict import TreeOfLifeClassifier, Rank, CustomLabelsClassifier, CustomLabelsBinningClassifier, BIOCLIP_MODEL_STR, BIOCLIP_V2_MODEL_STR, BIOCLIP_V1_MODEL_STR
+from bioclip.predict import TreeOfLifeClassifier, Rank, CustomLabelsClassifier, CustomLabelsBinningClassifier, BIOCLIP_MODEL_STR, BIOCLIP_V2_MODEL_STR, BIOCLIP_V1_MODEL_STR, BIOCLIP_V25_HUGE_MODEL_STR, BIOCAP_MODEL_STR
 
-__all__ = ["TreeOfLifeClassifier", "Rank", "CustomLabelsClassifier", "CustomLabelsBinningClassifier", "BIOCLIP_MODEL_STR", "BIOCLIP_V2_MODEL_STR", "BIOCLIP_V1_MODEL_STR"]
+__all__ = ["TreeOfLifeClassifier", "Rank", "CustomLabelsClassifier", "CustomLabelsBinningClassifier", "BIOCLIP_MODEL_STR", "BIOCLIP_V2_MODEL_STR", "BIOCLIP_V1_MODEL_STR", "BIOCLIP_V25_HUGE_MODEL_STR", "BIOCAP_MODEL_STR"]

--- a/src/bioclip/predict.py
+++ b/src/bioclip/predict.py
@@ -354,18 +354,16 @@ class BaseClassifier(nn.Module):
             torch.Tensor: A tensor containing the text embeddings for the tree of life.
         """
         model_name = self.model_str.split("/")[1]
-        txt_emb_npy = self.get_cached_datafile(f"embeddings/{model_name}/txt_emb_species.npy")
+        txt_emb_npy = self.get_cached_datafile(f"embeddings/txt_emb_{model_name}.npy")
         return torch.from_numpy(np.load(txt_emb_npy))
 
     def get_txt_names(self) -> List[List[str]]:
         """
         Retrieves TreeOfLife text names for the current model from the  associated Hugging Face dataset repo.
-        model_str formatted 'hf-hub:imageomics/<model_name>'
         Returns:
             List[List[str]]: A list of lists, where each inner list contains names corresponding to the text embeddings.
         """
-        model_name = self.model_str.split("/")[1]
-        txt_names_json = self.get_cached_datafile(f"embeddings/{model_name}/txt_emb_species.json")
+        txt_names_json = self.get_cached_datafile(f"embeddings/txt_emb_species.json")
         with open(txt_names_json, encoding="utf-8") as fd:
             txt_names = json.load(fd)
         return txt_names

--- a/src/bioclip/predict.py
+++ b/src/bioclip/predict.py
@@ -20,12 +20,18 @@ TOL10M_HF_DATAFILE_REPO = "imageomics/TreeOfLife-10M"
 TOL200M_HF_DATAFILE_REPO = "imageomics/TreeOfLife-200M"
 HF_DATAFILE_REPO_TYPE = "dataset"
 
-BIOCLIP_V1_MODEL_STR = "hf-hub:imageomics/bioclip" # TODO
+# BioCLIP family of models
+BIOCLIP_V1_MODEL_STR = "hf-hub:imageomics/bioclip"
 BIOCLIP_V2_MODEL_STR = "hf-hub:imageomics/bioclip-2"
+BIOCLIP_V25_HUGE_MODEL_STR = "hf-hub:imageomics/bioclip-2.5-vith14"
+BIOCAP_MODEL_STR = "hf-hub:imageomics/biocap"
+# Set default model
 BIOCLIP_MODEL_STR = BIOCLIP_V2_MODEL_STR
 TOL_MODELS = {
     BIOCLIP_V1_MODEL_STR: TOL10M_HF_DATAFILE_REPO,
-    BIOCLIP_V2_MODEL_STR: TOL200M_HF_DATAFILE_REPO
+    BIOCLIP_V2_MODEL_STR: TOL200M_HF_DATAFILE_REPO,
+    BIOCLIP_V25_HUGE_MODEL_STR: TOL200M_HF_DATAFILE_REPO,
+    BIOCAP_MODEL_STR: TOL10M_HF_DATAFILE_REPO
 }
 PRED_FILENAME_KEY = "file_name"
 PRED_CLASSICATION_KEY = "classification"
@@ -343,19 +349,23 @@ class BaseClassifier(nn.Module):
     def get_txt_emb(self) -> torch.Tensor:
         """
         Retrieves TreeOfLife text embeddings for the current model from the associated Hugging Face dataset repo.
+        model_str formatted 'hf-hub:imageomics/<model_name>'
         Returns:
             torch.Tensor: A tensor containing the text embeddings for the tree of life.
         """
-        txt_emb_npy = self.get_cached_datafile("embeddings/txt_emb_species.npy")
+        model_name = self.model_str.split("/")[1]
+        txt_emb_npy = self.get_cached_datafile(f"embeddings/{model_name}/txt_emb_species.npy")
         return torch.from_numpy(np.load(txt_emb_npy))
 
     def get_txt_names(self) -> List[List[str]]:
         """
         Retrieves TreeOfLife text names for the current model from the  associated Hugging Face dataset repo.
+        model_str formatted 'hf-hub:imageomics/<model_name>'
         Returns:
             List[List[str]]: A list of lists, where each inner list contains names corresponding to the text embeddings.
         """
-        txt_names_json = self.get_cached_datafile("embeddings/txt_emb_species.json")
+        model_name = self.model_str.split("/")[1]
+        txt_names_json = self.get_cached_datafile(f"embeddings/{model_name}/txt_emb_species.json")
         with open(txt_names_json, encoding="utf-8") as fd:
             txt_names = json.load(fd)
         return txt_names

--- a/src/bioclip/predict.py
+++ b/src/bioclip/predict.py
@@ -27,6 +27,7 @@ BIOCLIP_V25_HUGE_MODEL_STR = "hf-hub:imageomics/bioclip-2.5-vith14"
 BIOCAP_MODEL_STR = "hf-hub:imageomics/biocap"
 # Set default model
 BIOCLIP_MODEL_STR = BIOCLIP_V2_MODEL_STR
+# Define TOL datasets associated to the BioCLIP models
 TOL_MODELS = {
     BIOCLIP_V1_MODEL_STR: TOL10M_HF_DATAFILE_REPO,
     BIOCLIP_V2_MODEL_STR: TOL200M_HF_DATAFILE_REPO,
@@ -363,7 +364,7 @@ class BaseClassifier(nn.Module):
         Returns:
             List[List[str]]: A list of lists, where each inner list contains names corresponding to the text embeddings.
         """
-        txt_names_json = self.get_cached_datafile(f"embeddings/txt_emb_species.json")
+        txt_names_json = self.get_cached_datafile("embeddings/txt_emb_species.json")
         with open(txt_names_json, encoding="utf-8") as fd:
             txt_names = json.load(fd)
         return txt_names

--- a/src/bioclip/predict.py
+++ b/src/bioclip/predict.py
@@ -323,11 +323,13 @@ class BaseClassifier(nn.Module):
 
     def get_txt_names(self) -> List[List[str]]:
         """
-        Retrieves TreeOfLife text names for the current model from the  associated Hugging Face dataset repo.
+        Retrieves TreeOfLife text names for the current model from the associated Hugging Face dataset repo.
+        model_str formatted 'hf-hub:imageomics/<model_name>'
         Returns:
             List[List[str]]: A list of lists, where each inner list contains names corresponding to the text embeddings.
         """
-        txt_names_json = self.get_cached_datafile("embeddings/txt_emb_species.json")
+        model_name = self.model_str.split("/")[1]
+        txt_names_json = self.get_cached_datafile(f"embeddings/txt_emb_{model_name}.json")
         with open(txt_names_json, encoding="utf-8") as fd:
             txt_names = json.load(fd)
         return txt_names


### PR DESCRIPTION
Incorporates newer models (BioCAP and BioCLIP 2.5 Huge) as "TreeOfLife Models" for full functionality, e.g., `TreeOfLifeClassifier` use. This reworks the reading of text embeddings from the datasets, as incorporated in [TreeOfLife-10M PR 13](https://huggingface.co/datasets/imageomics/TreeOfLife-10M/discussions/13).

This update still needs tests and is pending updates to the dataset repositories. ~Current tests that call the text embeddings will fail until those repos are updated.~ Tests only check with default model (BioCLIP 2), so passing locally following [the addition of model-named text embeddings to TreeOfLife-200M](https://huggingface.co/datasets/imageomics/TreeOfLife-200M/commit/94bbc0b90cd26cbb15f94d3144941026f4b41213).

- [ ] [TreeOfLife-10M PR 13](https://huggingface.co/datasets/imageomics/TreeOfLife-10M/discussions/13)
- [x] Update to TreeOfLife-200M to include `txt_emb_bioclip-2.npy` and `txt_emb_bioclip-2.5-vith14.npy` in the `embeddings/` directory.

Note that [TreeOfLife-10M PR 13](https://huggingface.co/datasets/imageomics/TreeOfLife-10M/discussions/13) and the corresponding [BioCLIP update](https://huggingface.co/imageomics/bioclip/discussions/10), will change the model weights used when calling the original BioCLIP model with `pybioclip`. These updated weights are due to a taxonomic fix applied; please see the Hugging Face repositories for more details.

Closes #161.