### PR TITLE
Update citation to match new release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,12 +10,12 @@ authors:
   - family-names: Campolongo
     given-names: "Elizabeth G."
 identifiers:
-  - description: "The GitHub release URL of tag 2.1.1."
+  - description: "The GitHub release URL of tag 2.1.3."
     type: url
-    value: "https://github.com/Imageomics/pybioclip/releases/tag/2.1.1"
-  - description: "The GitHub URL of the commit tagged with 2.1.1."
+    value: "https://github.com/Imageomics/pybioclip/releases/tag/2.1.3"
+  - description: "The GitHub URL of the commit tagged with 2.1.3."
     type: url
-    value: "https://github.com/Imageomics/pybioclip/tree/04d1f293fa353396a317e07598c8a019dd6af5f8"
+    value: "https://github.com/Imageomics/pybioclip/tree/5042999391b23eb93d887e5b235023b05b9a4806"
 repository-code: 'https://github.com/Imageomics/pybioclip'
 url: 'https://github.com/Imageomics/pybioclip'
 abstract: Python package and command line tool that simplifies using the BioCLIP foundation model.
@@ -41,6 +41,6 @@ keywords:
   - genus
   - "image classification"
 license: MIT
-version: 2.1.1
-date-released: '2025-09-17'
+version: 2.1.3
+date-released: '2026-04-13'
 doi: 10.5281/zenodo.13151194

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ See the [pybioclip documentation website](https://imageomics.github.io/pybioclip
 
 Our code (this repository):
 ```bibtex
-@software{Bradley_pybioclip_2025,
+@software{Bradley_pybioclip_2026,
 author = {Bradley, John and Lapp, Hilmar and Campolongo, Elizabeth G.},
 doi = {10.5281/zenodo.13151194},
-month = sept,
+month = apr,
 title = {{pybioclip}},
 version = {2.1.3},
-year = {2025}
+year = {2026}
 }
 ```
 


### PR DESCRIPTION
The [2.1.3 release](https://github.com/Imageomics/pybioclip/releases/tag/2.1.3) didn't include an update to the citation file to match, nor the date in the README. This PR updates both to match.