### PR TITLE
Removes redundant citation record from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See the [pybioclip documentation website](https://imageomics.github.io/pybioclip
 
 ## Citation
 
-To cite this repository, please use the citation provided by _Cite this repository_ in the sidebar, which uses the information in the `CITATON.cff` file. If you need a citation with a version-specific DOI, you can obtain this by following the Zenodo DOI badge at the top.
+To cite this repository, please use the citation provided by _Cite this repository_ in the sidebar, which uses the information in the `CITATON.cff` file. If you need a citation with a version-specific DOI, you can obtain this by following the Zenodo DOI badge at the top of this file.
 
 Unless you selected (via `--model`) a model different from the default (which is now BioCLIP 2), please also cite the BioCLIP 2 paper:
 ```bibtex

--- a/README.md
+++ b/README.md
@@ -18,17 +18,7 @@ See the [pybioclip documentation website](https://imageomics.github.io/pybioclip
 
 ## Citation
 
-Our code (this repository):
-```bibtex
-@software{Bradley_pybioclip_2025,
-author = {Bradley, John and Lapp, Hilmar and Campolongo, Elizabeth G.},
-doi = {10.5281/zenodo.13151194},
-month = sept,
-title = {{pybioclip}},
-version = {2.1.3},
-year = {2025}
-}
-```
+To cite this repository, please use the citation provided by _Cite this repository_ in the sidebar, which uses the information in the `CITATON.cff` file. If you need a citation with a version-specific DOI, you can obtain this by following the Zenodo DOI badge at the top.
 
 Unless you selected (via `--model`) a model different from the default (which is now BioCLIP 2), please also cite the BioCLIP 2 paper:
 ```bibtex


### PR DESCRIPTION
As per the [resolution](https://github.com/Imageomics/pybioclip/pull/176#issuecomment-4261604994) to the remaining part of #176.