### PR TITLE
Fix broken CLI commands caused by lazy-import None placeholders

### DIFF
--- a/src/bioclip/__init__.py
+++ b/src/bioclip/__init__.py
@@ -12,13 +12,6 @@ __all__ = [
     Rank,
     BIOCLIP_MODEL_STR, BIOCLIP_V2_MODEL_STR, BIOCLIP_V1_MODEL_STR,
 ]
-
-# Placeholders so all explicit exports are defined at module scope.
-# Real values are loaded lazily in __getattr__.
-TreeOfLifeClassifier = None
-CustomLabelsClassifier = None
-CustomLabelsBinningClassifier = None
-
 def __getattr__(name):
     if name in __all__:
         from bioclip.predict import TreeOfLifeClassifier, CustomLabelsClassifier, CustomLabelsBinningClassifier


### PR DESCRIPTION
## Problem

3 out of 4 CLI subcommands (`predict`, `embed`, `list-tol-taxa`) crash with `TypeError: 'NoneType' object is not callable` because `from bioclip import TreeOfLifeClassifier` in `commands.py` binds `None` at import time instead of the actual class.

## Root Cause

Commit c5f25db added module-level placeholder assignments (`TreeOfLifeClassifier = None`, etc.) to silence a code-quality warning about undefined explicit exports. However, these placeholders populate the module `__dict__`, so Python's `__getattr__` — which handles the actual lazy import — is never triggered. The names resolve to `None` instead of their real classes from `bioclip.predict`.

## Fix

Remove the three `= None` placeholder lines (lines 18–20 in `__init__.py`). With the names absent from the module dict, `__getattr__` fires correctly and loads the real classes lazily. The `--help` startup speed optimization from #179 is preserved since `__main__.py` already defers the import via `from bioclip import commands`.

## Testing

- `list-models` (the one working command) continues to work — its branch only uses `open_clip`.
- The other three commands should now resolve their classifiers correctly instead of crashing on `None`.
- Existing tests in `test_predict.py` import from `bioclip.predict` directly (bypassing `__init__.py`), so they remain unaffected. CLI-level tests exercising `commands.py` would be a good addition in a follow-up (as noted in #183).

Fixes #183