### PR TITLE
Fixes the lazy-loading issue by loading classifiers from .predict

### DIFF
--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1,6 +1,6 @@
 # Python API
 
-::: bioclip.TreeOfLifeClassifier
+::: bioclip.predict.TreeOfLifeClassifier
     options:
       members:
       - predict
@@ -22,14 +22,14 @@
 -  `GENUS`
 -  `SPECIES`
 
-::: bioclip.CustomLabelsClassifier
+::: bioclip.predict.CustomLabelsClassifier
     options:
       members:
       - predict
       show_root_heading: true
       show_source: true
 
-::: bioclip.CustomLabelsBinningClassifier
+::: bioclip.predict.CustomLabelsBinningClassifier
     options:
       members:
       - predict

--- a/docs/python-tutorial.md
+++ b/docs/python-tutorial.md
@@ -6,7 +6,8 @@ and [`Felis-catus.jpeg`](https://huggingface.co/spaces/imageomics/bioclip-demo/b
 ## Predict species classification
 
 ```python
-from bioclip import TreeOfLifeClassifier, Rank
+from bioclip import Rank
+from bioclip.predict import TreeOfLifeClassifier
 
 classifier = TreeOfLifeClassifier()
 predictions = classifier.predict("Ursus-arctos.jpeg", Rank.SPECIES)
@@ -47,7 +48,8 @@ Output from the `predict()` method showing the dictionary structure:
 The output from the predict function can be converted into a [pandas DataFrame](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html) like so:
 ```python
 import pandas as pd
-from bioclip import TreeOfLifeClassifier, Rank
+from bioclip import Rank
+from bioclip.predict import TreeOfLifeClassifier
 
 classifier = TreeOfLifeClassifier()
 predictions = classifier.predict("Ursus-arctos.jpeg", Rank.SPECIES)
@@ -61,7 +63,7 @@ The first argument of the `predict()` method supports both a single path or a li
 
 ## Predict from a list of classes
 ```python
-from bioclip import CustomLabelsClassifier
+from bioclip.predict import CustomLabelsClassifier
 
 classifier = CustomLabelsClassifier(["duck","fish","bear"])
 predictions = classifier.predict("Ursus-arctos.jpeg")
@@ -82,7 +84,7 @@ bear 1.0
 To predict with a custom model the `model_str` and `pretrained_str` arguments must be specified.
 In this example the [CLIP-ViT-B-16-laion2B-s34B-b88K](https://huggingface.co/laion/CLIP-ViT-B-16-laion2B-s34B-b88K) model is used.
 ```python
-from bioclip import CustomLabelsClassifier
+from bioclip.predict import CustomLabelsClassifier
 
 classifier = CustomLabelsClassifier(
     cls_ary = ["duck","fish","bear"],
@@ -94,7 +96,8 @@ print(classifier.predict("Ursus-arctos.jpeg"))
 
 ### Predict with the original BioCLIP model
 ```python
-from bioclip import CustomLabelsClassifier, BIOCLIP_V1_MODEL_STR
+from bioclip.predict import CustomLabelsClassifier
+from bioclip import BIOCLIP_V1_MODEL_STR
 
 classifier = CustomLabelsClassifier(
     cls_ary = ["duck","fish","bear"],
@@ -108,7 +111,7 @@ See [this tutorial](command-line-tutorial.md/#predict-using-a-custom-model) for 
 
 ## Predict from a list of classes with binning
 ```python
-from bioclip import CustomLabelsBinningClassifier
+from bioclip.predict import CustomLabelsBinningClassifier
 
 classifier = CustomLabelsBinningClassifier(cls_to_bin={
   'dog': 'small',

--- a/src/bioclip/__init__.py
+++ b/src/bioclip/__init__.py
@@ -7,13 +7,11 @@ from bioclip._constants import (
     BIOCLIP_MODEL_STR, BIOCLIP_V2_MODEL_STR, BIOCLIP_V1_MODEL_STR,
 )
 
-__all__ = [
+__exports__ = [
     "TreeOfLifeClassifier", "CustomLabelsClassifier", "CustomLabelsBinningClassifier",
-    Rank,
-    BIOCLIP_MODEL_STR, BIOCLIP_V2_MODEL_STR, BIOCLIP_V1_MODEL_STR,
 ]
 def __getattr__(name):
-    if name in __all__:
+    if name in __exports__:
         from bioclip.predict import TreeOfLifeClassifier, CustomLabelsClassifier, CustomLabelsBinningClassifier
         g = globals()
         g['TreeOfLifeClassifier'] = TreeOfLifeClassifier


### PR DESCRIPTION
In essence, this is a precursor to an API chaange, which consists of loading the classifier classes from the root namespace (`bioclip`) to `bioclip.predict`).

This is trying to maintain backward compatibility for now by making the classes available if someone imports them from the root namespace. But at some future point we can start deprecating and ultimately removing this.

The underlying rationale here is that lazy-loading heavy imports is really only needed for the command line, and not in library use, because `--help` is only relevant for the CLI. The solution then is to keep all heavy non-local imports out of `__main__.py` *and* `__init__.py` (which gets loaded for CLI too).