### PR TITLE
Moves classifier imports to using bioclip.predict

### DIFF
--- a/src/bioclip/commands.py
+++ b/src/bioclip/commands.py
@@ -1,4 +1,4 @@
-from bioclip import TreeOfLifeClassifier, CustomLabelsClassifier, CustomLabelsBinningClassifier
+from bioclip.predict import TreeOfLifeClassifier, CustomLabelsClassifier, CustomLabelsBinningClassifier
 from ._constants import TOL_MODELS, Rank, DEFAULT_BATCH_SIZE
 from .recorder import attach_prediction_recorder, save_recorded_predictions, verify_recorder_path
 import open_clip as oc


### PR DESCRIPTION
This is for consistency with the rest. (It would still work without this change.) Doing the same for the Jupyter notebooks is deferred until a subsequent release.