### PR TITLE
Fix TypeError from over-squeezing torch.nonzero() in format_grouped_probs

### DIFF
--- a/src/bioclip/predict.py
+++ b/src/bioclip/predict.py
@@ -613,7 +613,7 @@ class TreeOfLifeClassifier(BaseClassifier):
         output = collections.defaultdict(float)
         class_dict_lookup = {}
         name_to_class_dict = {}
-        for i in torch.nonzero(probs > min_prob).squeeze():
+        for i in torch.nonzero(probs > min_prob).squeeze(-1):
             classification_dict = self.get_classification_dict(i, rank)
             name = join_names(classification_dict)
             class_dict_lookup[name] = classification_dict

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -113,6 +113,31 @@ class TestPredict(unittest.TestCase):
             ANY, 2
         )
 
+    def test_format_grouped_probs_squeeze_dim(self):
+        # Regression test for #200: torch.nonzero(...).squeeze() collapsed to a
+        # 0-d tensor (unindexable) when exactly one entry exceeded min_prob.
+        # squeeze(-1) must keep the result iterable for N == 0, N == 1, and N > 1.
+        classifier = TreeOfLifeClassifier()
+        classifier.get_classification_dict = Mock(
+            side_effect=lambda idx, rank: {'kingdom': f'Kingdom{int(idx)}'}
+        )
+
+        # N == 0: nothing exceeds min_prob
+        probs = torch.tensor([0.0, 0.0, 0.0])
+        result = classifier.format_grouped_probs(EXAMPLE_CAT_IMAGE, probs, Rank.KINGDOM)
+        self.assertEqual(result, [])
+
+        # N == 1: exactly one entry exceeds min_prob (this used to crash)
+        probs = torch.tensor([0.9, 0.0, 0.0])
+        result = classifier.format_grouped_probs(EXAMPLE_CAT_IMAGE, probs, Rank.KINGDOM)
+        self.assertEqual(len(result), 1)
+        self.assertAlmostEqual(result[0]['score'], 0.9)
+
+        # N > 1: multiple entries exceed min_prob
+        probs = torch.tensor([0.9, 0.5, 0.0])
+        result = classifier.format_grouped_probs(EXAMPLE_CAT_IMAGE, probs, Rank.KINGDOM)
+        self.assertEqual(len(result), 2)
+
     def test_custom_labels_classifier(self):
         classifier = CustomLabelsClassifier(cls_ary=['cat', 'dog'])
         prediction_ary = classifier.predict(images=EXAMPLE_CAT_IMAGE)


### PR DESCRIPTION
Fixes #200

## Problem
`TreeOfLifeClassifier.predict()` raised `TypeError: iteration over a 0-d tensor` when called with a rank above species (e.g. `Rank.GENUS`) whenever the model's confidence was peaked enough that exactly one species-level probability exceeded `min_prob`.

## Root cause
In `predict.py`, `format_grouped_probs` used:

``` python
for i in torch.nonzero(probs > min_prob).squeeze():
```

`torch.nonzero(...)` returns a tensor of shape `(N, 1)`. Calling `.squeeze()` with no argument removes *all* size-1 dimensions, so when `N == 1` the shape collapses from `(1, 1)` to `()` — a non-iterable 0-d scalar tensor.

This only affected non-species ranks, since species-rank requests are routed to `format_species_probs`, which uses `topk` and is unaffected.

## Fix
Replace `.squeeze()` with `.squeeze(-1)`, so only the known size-1 column dimension is removed and the "number of matches" dimension is always preserved, including when it's 0 or 1:

``` python
for i in torch.nonzero(probs > min_prob).squeeze(-1):
```

## Testing
Verified locally that this resolves the `N == 1` case and produces identical output to before for `N > 1`.